### PR TITLE
docs: mention the Harness Desktop built-in marketplace

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,17 +15,6 @@ A plugin marketplace for [DeepSeek Harness](https://github.com/deepseek-ai/deeps
 
 ---
 
-## 🖥️ Included in a Windows desktop app
-
-Prefer not to use the command line? [Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) includes this marketplace. Install the desktop app, then open **Settings → DSH Plugin Marketplace** to browse, install, and update community plugins.
-
-- [Project home](https://github.com/baiyuscc13724-max/deepseek-harness-desktop)
-- [Windows installer and portable downloads](https://github.com/baiyuscc13724-max/deepseek-harness-desktop/releases)
-
-Harness Desktop is a community project. The marketplace itself remains independently maintained in this repository.
-
----
-
 ## ⚡ Quick install (copy & run)
 
 **One sentence to hand to an AI** (any AI with command execution works — no further explanation needed):
@@ -203,6 +192,14 @@ When both exist and differ → the card shows an «Update» button plus `install
 - **Skills index scope**: bounded by the GitHub Search API hard cap (1000 results per query) — `skills.json` currently covers the 1000 most recently updated repos of each of `agent-skills` and `claude-skills` (1867 repos after dedup); a full index (topic-page crawling) is planned for v1.3
 - «Installed» recognition for script-type plugins is based on cache-dir existence; after deleting the cache it will show as installable again
 - Plugin code changes require a **DSH restart** to take effect (the web profile's HMR is disabled)
+
+---
+
+## 🌱 Third-party ecosystem
+
+[Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) is a third-party, community-maintained Windows desktop app. Its stable release includes this marketplace, so users can browse, install, and update community plugins from **Settings → DSH Plugin Marketplace** without using the command line.
+
+This entry was submitted by the Harness Desktop author, who also maintains the DSH-Plugins-Marketplace fork used by the desktop app. Harness Desktop has no official affiliation with this repository or DeepSeek.
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -15,6 +15,17 @@ A plugin marketplace for [DeepSeek Harness](https://github.com/deepseek-ai/deeps
 
 ---
 
+## 🖥️ Included in a Windows desktop app
+
+Prefer not to use the command line? [Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) includes this marketplace. Install the desktop app, then open **Settings → DSH Plugin Marketplace** to browse, install, and update community plugins.
+
+- [Project home](https://github.com/baiyuscc13724-max/deepseek-harness-desktop)
+- [Windows installer and portable downloads](https://github.com/baiyuscc13724-max/deepseek-harness-desktop/releases)
+
+Harness Desktop is a community project. The marketplace itself remains independently maintained in this repository.
+
+---
+
 ## ⚡ Quick install (copy & run)
 
 **One sentence to hand to an AI** (any AI with command execution works — no further explanation needed):

--- a/README.md
+++ b/README.md
@@ -15,17 +15,6 @@
 
 ---
 
-## 🖥️ Windows 桌面版内置
-
-不想用命令行安装？[Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) 已经内置本插件市场。安装桌面版后，打开 **设置 → DSH插件市场**，就能直接查看、安装和更新社区插件。
-
-- [项目主页](https://github.com/baiyuscc13724-max/deepseek-harness-desktop)
-- [Windows 安装版和免安装版](https://github.com/baiyuscc13724-max/deepseek-harness-desktop/releases)
-
-Harness Desktop 是社区项目；插件市场本体仍由本仓库独立维护。
-
----
-
 ## ⚡ 一键安装（复制即用）
 
 **喂给 AI 的一句话**（AI 具备命令执行能力即可，无需解释）：
@@ -203,6 +192,14 @@ GitHub Actions（每 2 小时，仓库自带 token）
 - **Skills 索引范围**：受 GitHub Search API 单 query 硬上限（1000 条）约束，`skills.json` 当前收录 `agent-skills` 与 `claude-skills` 两个 topic 各自最新更新的 1000 条（并集 1867 个仓库）；全量索引（topic 页爬取）计划在 v1.3 实现
 - 安装脚本类插件的「已安装」判定基于缓存目录存在性，卸载（删除缓存）后会重新显示为可安装
 - 插件代码修改后需**重启 DSH** 才能生效（Web profile 的 HMR 处于禁用状态）
+
+---
+
+## 🌱 第三方生态
+
+[Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) 是第三方社区维护的 Windows 桌面版，稳定版已内置本插件市场。用户可以在 **设置 → DSH插件市场** 中直接查看、安装和更新社区插件，无需使用命令行。
+
+此条目由 Harness Desktop 作者提交；该作者同时维护桌面端使用的 DSH-Plugins-Marketplace 分支。Harness Desktop 与本仓库及 DeepSeek 官方均无官方关联。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 
 ---
 
+## 🖥️ Windows 桌面版内置
+
+不想用命令行安装？[Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) 已经内置本插件市场。安装桌面版后，打开 **设置 → DSH插件市场**，就能直接查看、安装和更新社区插件。
+
+- [项目主页](https://github.com/baiyuscc13724-max/deepseek-harness-desktop)
+- [Windows 安装版和免安装版](https://github.com/baiyuscc13724-max/deepseek-harness-desktop/releases)
+
+Harness Desktop 是社区项目；插件市场本体仍由本仓库独立维护。
+
+---
+
 ## ⚡ 一键安装（复制即用）
 
 **喂给 AI 的一句话**（AI 具备命令执行能力即可，无需解释）：


### PR DESCRIPTION
Harness Desktop now includes this marketplace in its official Harness settings view. This small bilingual README update adds permanent project and Releases links, so Windows users can find the no-command-line option without tying the documentation to a particular app version.