### PR TITLE
fix: simplify plugin and multi-Skill installation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,10 +39,11 @@ window.__ModuleLoader__.load({
       install: "安装",
       update: "更新",
       installing: "安装中...",
+      runningMsg: "正在下载并检查安装内容，请稍候…",
       updateHint: "已装 v{old} → v{new}",
-      inputTitle: "需要你提供材料才能继续安装 {repo}",
+      inputTitle: "安装前需要确认 {repo}",
       placeholder: "粘贴 {name} 的值（如 API Key）",
-      submitContinue: "提交材料并继续安装",
+      submitContinue: "确认并继续",
       cancel: "取消",
       panelTitle: "安装 {repo} ({phase})",
       "phase.running": "运行中",
@@ -52,6 +53,7 @@ window.__ModuleLoader__.load({
       "phase.failed": "失败",
       "phase.manual": "无法自动安装",
       doneMsg: "安装完成 ✔ 类型: {type}",
+      doneSkills: "安装完成 ✔ 已安装 {count} 个 Skills",
       doneMsgLoc: " · 位置: {loc}",
       manualMsg: "该项目无法一键安装（无 SKILL.md / agent 预设 / 安装脚本 / 插件清单），什么都不会被安装。它可能是聚合页或文档仓库，请前往仓库自行安装：{url}",
       abortedMsg: "安装已取消",
@@ -91,10 +93,11 @@ window.__ModuleLoader__.load({
       install: "Install",
       update: "Update",
       installing: "Installing...",
+      runningMsg: "Downloading and checking the package…",
       updateHint: "v{old} → v{new} installed",
-      inputTitle: "Input required to continue installing {repo}",
+      inputTitle: "Confirm before installing {repo}",
       placeholder: "Paste value for {name} (e.g. API key)",
-      submitContinue: "Submit and continue install",
+      submitContinue: "Confirm and continue",
       cancel: "Cancel",
       panelTitle: "Installing {repo} ({phase})",
       "phase.running": "running",
@@ -104,6 +107,7 @@ window.__ModuleLoader__.load({
       "phase.failed": "failed",
       "phase.manual": "manual install required",
       doneMsg: "Install complete ✔ Type: {type}",
+      doneSkills: "Install complete ✔ {count} Skills installed",
       doneMsgLoc: " · Location: {loc}",
       manualMsg: "This repo cannot be installed with one click (no SKILL.md / agent preset / install script / plugin manifest), so nothing was installed. It may be a curated list or documentation repo — please install it manually: {url}",
       abortedMsg: "Install cancelled",
@@ -132,18 +136,6 @@ window.__ModuleLoader__.load({
       for (var i = 0; i < localeChangeCbs.length; i++) {
         try { localeChangeCbs[i](); } catch (e) { /* ignore */ }
       }
-    }
-
-    // 滚动到安装面板（页面顶部）：兼容窗口滚动与设置页内部的可滚动容器
-    function scrollPanelIntoView() {
-      try {
-        var panel = document.getElementById("dshm-install-panel");
-        if (panel && panel.scrollIntoView) {
-          panel.scrollIntoView({ behavior: "smooth", block: "start" });
-          return;
-        }
-      } catch (e) { /* fallthrough */ }
-      try { window.scrollTo({ top: 0, behavior: "smooth" }); } catch (e) { window.scrollTo(0, 0); }
     }
 
     // 排序：已安装置顶，其余按 Star 数从高到低
@@ -180,7 +172,8 @@ window.__ModuleLoader__.load({
       q: { fontSize: 13, margin: "0 0 2px", color: "var(--dsw-alias-label-secondary)", whiteSpace: "pre-wrap", wordBreak: "break-word" },
       badge: { display: "inline-block", padding: "1px 8px", borderRadius: 10, fontSize: 11, border: "1px solid var(--dsw-alias-border-l3)", color: "var(--dsw-alias-label-tertiary)", marginLeft: 8 },
       badgeShield: { display: "inline-block", padding: "1px 8px", borderRadius: 10, fontSize: 11, border: "1px solid var(--dsw-alias-state-warn-secondary, #b45309)", color: "var(--dsw-alias-state-warn-primary)", marginLeft: 8 },
-      panel: { border: "1px solid var(--dsw-alias-border-l2)", borderRadius: 10, padding: "12px 14px", marginBottom: 12, background: "var(--dsw-alias-bg-layer-2)" },
+      installOverlay: { position: "fixed", inset: 0, zIndex: 2100, display: "grid", placeItems: "center", padding: 20, background: "rgba(15,23,42,.42)", backdropFilter: "blur(4px)" },
+      panel: { boxSizing: "border-box", width: "min(620px, calc(100vw - 40px))", maxHeight: "min(720px, calc(100vh - 40px))", overflow: "auto", border: "1px solid var(--dsw-alias-border-l2)", borderRadius: 14, padding: "18px 20px", background: "var(--dsw-alias-bg-layer-2)", boxShadow: "var(--dsw-shadow-lv4, 0 24px 70px rgba(0,0,0,.3))" },
       err: { color: "var(--dsw-alias-state-error-primary)", fontSize: 13, margin: "8px 0 0" },
       errRow: { display: "flex", alignItems: "center", gap: 10, margin: "8px 0 0" },
       toast: { position: "fixed", top: 24, left: "50%", transform: "translateX(-50%)", zIndex: 2000, maxWidth: "80vw", padding: "8px 16px", borderRadius: 10, fontSize: 13, boxShadow: "var(--dsw-shadow-lv3, 0 8px 24px rgba(0,0,0,.25))", background: "var(--dsw-alias-button-contrast-fill)", color: "var(--dsw-alias-label-primary-inverted)" },
@@ -197,7 +190,10 @@ window.__ModuleLoader__.load({
         ".dshm-btn:disabled{opacity:.55;cursor:default}",
         ".dshm-btn-primary:hover{background:var(--dsw-alias-button-primary-hover)}",
         ".dshm-btn-danger:hover{background:var(--dsw-alias-interactive-bg-hover-danger)}",
-        ".dshm-btn:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:1px}"
+        ".dshm-btn:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:1px}",
+        "@keyframes dshm-progress{0%{transform:translateX(-100%)}100%{transform:translateX(300%)}}",
+        ".dshm-progress{height:4px;margin:14px 0;overflow:hidden;border-radius:4px;background:var(--dsw-alias-bg-layer-3)}",
+        ".dshm-progress>span{display:block;width:34%;height:100%;border-radius:4px;background:var(--dsw-alias-brand-primary);animation:dshm-progress 1.15s ease-in-out infinite}"
       ].join("\n");
       document.head.appendChild(el);
     }
@@ -254,6 +250,7 @@ window.__ModuleLoader__.load({
       var inputValues = props.inputValues;
       var setInputValues = props.setInputValues;
       if (inst.phase === "input") {
+        var hasTextQuestion = inst.questions.some(function (q) { return !(q.options && q.options.length > 0); });
         return h("div", { id: "dshm-install-panel", style: s.panel },
           h("p", { style: s.title, margin: "0 0 8px" }, t("inputTitle", { repo: inst.repo })),
           h("div", { style: s.log }, inst.log.map(function (l, i) { return h("div", { key: i }, l); })),
@@ -291,7 +288,7 @@ window.__ModuleLoader__.load({
             );
           }),
           h("div", { style: { display: "flex", gap: 8, marginTop: 12 } },
-            h("button", { className: "dshm-btn dshm-btn-primary", style: s.btnPrimary, onClick: function () { props.submit(inputValues); } }, t("submitContinue")),
+            hasTextQuestion ? h("button", { className: "dshm-btn dshm-btn-primary", style: s.btnPrimary, onClick: function () { props.submit(inputValues); } }, t("submitContinue")) : null,
             h("button", { className: "dshm-btn", style: s.btn, onClick: props.cancel }, t("cancel"))
           )
         );
@@ -299,13 +296,17 @@ window.__ModuleLoader__.load({
       var phaseName = t("phase." + inst.phase) || inst.phase;
       return h("div", { id: "dshm-install-panel", style: s.panel },
         h("p", { style: s.title, margin: "0 0 8px" }, t("panelTitle", { repo: inst.repo, phase: phaseName })),
-        h("div", { style: s.log }, inst.log.map(function (l, i) { return h("div", { key: i }, l); })),
+        inst.phase === "running" ? h("div", null,
+          h("p", { style: s.sub }, t("runningMsg")),
+          h("div", { className: "dshm-progress", "aria-label": t("installing") }, h("span", null))
+        ) : null,
+        inst.log.length > 0 ? h("div", { style: s.log }, inst.log.map(function (l, i) { return h("div", { key: i }, l); })) : null,
         inst.result && (inst.result.status === "done") && h("p", { style: { fontSize: 13, margin: "10px 0 0", color: "var(--dsw-alias-state-success-primary)" } },
-          t("doneMsg", { type: inst.result.type }) + (inst.result.location ? t("doneMsgLoc", { loc: inst.result.location }) : "")),
+          (inst.result.count > 1 ? t("doneSkills", { count: inst.result.count }) : t("doneMsg", { type: inst.result.type })) + (inst.result.location ? t("doneMsgLoc", { loc: inst.result.location }) : "")),
         inst.result && (inst.result.status === "manual") && h("p", { style: s.err }, linkify(t("manualMsg", { url: inst.result.url || "" }))),
         inst.result && (inst.result.status === "aborted") && h("p", { style: s.err }, t("abortedMsg")),
         inst.result && (inst.result.status === "failed") && h("p", { style: s.err }, t("failedMsg", { err: (inst.result.error || "unknown") })),
-        h("button", { className: "dshm-btn", style: Object.assign({}, s.btn, { marginTop: 12 }), onClick: props.cancel }, t("backToList"))
+        inst.phase !== "running" ? h("button", { className: "dshm-btn", style: Object.assign({}, s.btn, { marginTop: 12 }), onClick: props.cancel }, t("backToList")) : null
       );
     }
 
@@ -471,17 +472,6 @@ window.__ModuleLoader__.load({
       var state5 = useState(0); var tick = state5[0]; var setTick = state5[1];
       var state7 = useState(null); var toast = state7[0]; var setToast = state7[1];
       var state8 = useState(0); var setRerender = state8[1];
-      var state9 = useState(null); var lastPhase = state9[0]; var setLastPhase = state9[1];
-
-      // 安装面板位于页面顶部：点击安装（或转入等待输入）时自动滚动过去，
-      // 让用户能看到进度/弹窗；日志追加（阶段不变）不触发滚动
-      useEffect(function () {
-        var phase = inst ? inst.phase : null;
-        if (phase !== lastPhase && (phase === "running" || phase === "input")) {
-          scrollPanelIntoView();
-        }
-        setLastPhase(phase);
-      });
 
       useEffect(function () {
         if (!toast) return;
@@ -557,7 +547,7 @@ window.__ModuleLoader__.load({
           h("button", { style: activeTab === "plugins" ? s.tabActive : s.tabBtn, onClick: function () { setActiveTab("plugins"); } }, t("tabPlugins")),
           h("button", { style: activeTab === "skills" ? s.tabActive : s.tabBtn, onClick: function () { setActiveTab("skills"); } }, t("tabSkills"))
         ),
-        inst ? h(InstallPanel, { inst: inst, inputValues: inputValues, setInputValues: setInputValues, submit: submit, cancel: cancelInstall }) : null,
+        inst ? h("div", { style: s.installOverlay }, h(InstallPanel, { inst: inst, inputValues: inputValues, setInputValues: setInputValues, submit: submit, cancel: cancelInstall })) : null,
         activeTab === "plugins" ? h(PluginTab, tabProps) : h(SkillsTab, tabProps),
         h("p", { key: "disclaimer", style: { fontSize: 11, color: "var(--dsw-alias-label-tertiary)", marginTop: 16, lineHeight: 1.6 } }, t("disclaimer"))
       );

--- a/lib/index.js
+++ b/lib/index.js
@@ -404,7 +404,7 @@ const MESSAGES = {
     "step4": "[4/5] 开始安装 ...",
     "step5": "[5/5] 完成。",
     "fail": "安装失败: {err}",
-    "skillInstalled": "skill「{name}」已安装到 {dest}，技能注册器将自动热加载。",
+    "skillInstalled": "Skill「{name}」已安装到 {dest}，技能注册器将自动热加载。",
     "presetInstalled": "agent 预设「{name}」已安装到 {dest}。",
     "runPs1": "正在执行 install.ps1 ...",
     "runSh": "正在执行 install.sh (bash) ...",
@@ -919,9 +919,37 @@ async function scanRequirements(cacheDir) {
   return [...names].slice(0, 8);
 }
 
+/** Find root and nested Agent Skills without following symlinks or dependency caches. */
+async function findSkillRoots(cacheDir, maxDepth = 5, limit = 200) {
+  const roots = [];
+  const walk = async (dir, depth) => {
+    if (roots.length >= limit) return;
+    let entries;
+    try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
+    if (entries.some((entry) => entry.isFile() && entry.name.toLowerCase() === "skill.md")) {
+      roots.push(dir);
+      return;
+    }
+    if (depth >= maxDepth) return;
+    for (const entry of entries) {
+      if (!entry.isDirectory() || [".git", "node_modules"].includes(entry.name)) continue;
+      await walk(join(dir, entry.name), depth + 1);
+      if (roots.length >= limit) return;
+    }
+  };
+  await walk(cacheDir, 0);
+  return roots;
+}
+
+async function readSkillManifest(skillRoot) {
+  const entries = await readdir(skillRoot).catch(() => []);
+  const manifest = entries.find((name) => name.toLowerCase() === "skill.md") ?? "SKILL.md";
+  return readFile(join(skillRoot, manifest), "utf8");
+}
+
 async function detectType(cacheDir) {
   const has = (p) => exists(join(cacheDir, p));
-  if (await has("SKILL.md")) return "skill";
+  if ((await findSkillRoots(cacheDir, 5, 1)).length > 0) return "skill";
   if ((await has("preset.yml")) && (await has("agent.cordis.yml"))) return "agent-preset";
   if (await has("install.ps1")) return "script";
   if (await has("install.sh")) return "script";
@@ -1102,7 +1130,8 @@ function apply(ctx) {
           // R3：键存在即视为「已提供（空值=跳过）」，未提供的键才继续要材料；
           // scannedVars 是完整扫描列表，后续作为 env 注入的白名单（不能只传过滤后的缺失项，
           // 否则用户已提交的键反而不在 allowedAnswers 里，插件拿不到密钥）。
-          const scannedVars = await scanRequirements(cacheDir);
+          // Skills and presets only copy files. README examples are not install-time API requirements.
+          const scannedVars = ["script", "cordis-plugin"].includes(type) ? await scanRequirements(cacheDir) : [];
           const required = scannedVars.filter((v) => !(v in answers));
           logLine(t(langFull, "step3", { list: required.length === 0 ? t(langFull, "none") : required.join(", ") }));
           if (required.length > 0) {
@@ -1282,19 +1311,31 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
     if (allowedAnswers.has(key)) env[key] = answers[key];
   }
   if (type === "skill") {
-    let skillName = slugify(repo.split("/")[1]);
-    try {
-      const text = await readFile(join(cacheDir, "SKILL.md"), "utf8");
-      const fm = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-      const m = fm && fm[1].match(/^name:\s*"?([a-z0-9][a-z0-9-]*)"?$/m);
-      if (m) skillName = m[1];
-    } catch { /* keep repo-derived name */ }
-    const dest = join(SKILLS_DIR, skillName);
+    const roots = await findSkillRoots(cacheDir);
+    if (roots.length === 0) throw new Error("No SKILL.md was found after cloning the repository.");
+    const installed = [];
     await mkdir(SKILLS_DIR, { recursive: true });
-    await rm(dest, { recursive: true, force: true });
-    await cp(cacheDir, dest, { recursive: true, filter: copyFilter(cacheDir, true) });
-    logLine(t(lang, "skillInstalled", { name: skillName, dest }));
-    return { type, name: skillName, location: dest };
+    for (const root of roots) {
+      let skillName = slugify(roots.length === 1 ? repo.split("/")[1] : root.split(sep).at(-1));
+      try {
+        const text = await readSkillManifest(root);
+        const fm = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+        const m = fm && fm[1].match(/^name:\s*"?([a-z0-9][a-z0-9-]*)"?$/m);
+        if (m) skillName = m[1];
+      } catch { /* keep path-derived name */ }
+      const dest = join(SKILLS_DIR, skillName);
+      await rm(dest, { recursive: true, force: true });
+      await cp(root, dest, { recursive: true, filter: copyFilter(root, true) });
+      installed.push({ name: skillName, location: dest });
+      logLine(t(lang, "skillInstalled", { name: skillName, dest }));
+    }
+    return {
+      type,
+      name: installed.length === 1 ? installed[0].name : `${installed.length}-skills`,
+      names: installed.map((item) => item.name),
+      count: installed.length,
+      location: installed.length === 1 ? installed[0].location : SKILLS_DIR
+    };
   }
   if (type === "agent-preset") {
     const presetId = slugify(repo.split("/")[1]);
@@ -1363,4 +1404,4 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, hasPatchEntry, normalizeRepo, appendPatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, hasPatchEntry, normalizeRepo, appendPatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, detectType };

--- a/scripts/guided-install-tests.mjs
+++ b/scripts/guided-install-tests.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectType, findSkillRoots } from "../lib/index.js";
+
+const repo = await mkdtemp(join(tmpdir(), "dsh-marketplace-multi-skill-"));
+try {
+  await mkdir(join(repo, "skills", "pdf"), { recursive: true });
+  await mkdir(join(repo, "skills", "slides"), { recursive: true });
+  await writeFile(join(repo, "skills", "pdf", "SKILL.md"), "---\nname: pdf\n---\n");
+  await writeFile(join(repo, "skills", "slides", "SKILL.md"), "---\nname: slides\n---\n");
+
+  const roots = await findSkillRoots(repo);
+  assert.deepEqual(roots.map((value) => value.split(/[\\/]/).at(-1)).sort(), ["pdf", "slides"]);
+  assert.equal(await detectType(repo), "skill");
+  console.log("2 passed, 0 failed");
+} finally {
+  await rm(repo, { recursive: true, force: true });
+}


### PR DESCRIPTION
## 这次改了什么

- 多 Skill 仓库会递归发现并安装所有 `SKILL.md`，例如 `anthropics/skills`。
- 普通 Skill 和 Agent preset 不再扫描 README 示例索要 API Key；只有实际脚本或 Cordis 插件需要时才提示环境变量。
- 插件与 Skill 安装时立即显示固定居中的进度窗口，不会让卡片消失或把页面滚到顶部。
- 安装过程中不能误关窗口；完成后明确显示结果和安装数量。
- 去掉只有选项时重复出现的通用提交按钮。

## 验证

- `node --check lib/index.js`
- `node --check lib/client.js`
- 原 smoke tests：70 passed，0 failed
- 新增多 Skill 测试：2 passed，0 failed

本 PR 没有修改 package 版本号、CHANGELOG、tag 或 GitHub Actions。