### PR TITLE
fix: 修复包名冲突重复展示与源码插件安装后无法启动

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -422,6 +422,18 @@ const MESSAGES = {
     "optDenyDesc": "不执行任何脚本，取消安装并清理痕迹",
     "npmScriptsDenied": "用户不允许执行第三方 npm 脚本，安装已取消，已清理全部痕迹。",
     "npmScriptsAllowed": "已允许执行第三方 npm 生命周期脚本。",
+    "buildDetected": "该插件只提交了源码（构建产物缺失），需要先构建再安装。",
+    "qBuildHeader": "确认执行构建",
+    "qBuild": "仓库 {repo} 的 package.json 声明了 build 脚本，但加载入口（main / client bundle）在仓库中缺失——不构建直接安装会导致 DSH 无法启动。构建会安装依赖并执行第三方构建脚本，是否允许？",
+    "optAllowBuild": "允许构建",
+    "optAllowBuildDesc": "信任该仓库，安装其构建依赖并执行构建脚本",
+    "optDenyBuild": "不允许（取消安装）",
+    "optDenyBuildDesc": "不执行任何构建，取消安装并清理痕迹",
+    "buildDenied": "用户不允许执行构建脚本，安装已取消，已清理全部痕迹。",
+    "buildInstall": "正在安装构建依赖 ({bin}) ...",
+    "buildRun": "正在执行构建 (pnpm run build) ...",
+    "buildDone": "构建完成。",
+    "buildFail": "构建失败: {err}",
     "npmLocalDeps": "检测到 {n} 个 pnpm 本地链接依赖（{names}），npm 无法安装，已从安装清单中移除（运行时由 DSH 宿主提供）。",
     "copied": "插件包已复制到 {dest}",
     "patchExists": "profile 补丁中已存在该插件条目，跳过注册。",
@@ -493,6 +505,18 @@ const MESSAGES = {
     "optDenyDesc": "Do not run any scripts; cancel the install and clean up",
     "npmScriptsDenied": "User denied third-party npm scripts — install cancelled, all traces cleaned up.",
     "npmScriptsAllowed": "Third-party npm lifecycle scripts allowed.",
+    "buildDetected": "This plugin ships source only (build output missing) and must be built before install.",
+    "qBuildHeader": "Confirm running the build",
+    "qBuild": "Repo {repo} declares a build script in package.json, but its load entries (main / client bundle) are missing from the repo — installing without building will make DSH fail to start. Building installs dependencies and runs third-party build scripts. Allow it?",
+    "optAllowBuild": "Allow build",
+    "optAllowBuildDesc": "Trust this repo, install its build dependencies and run the build script",
+    "optDenyBuild": "Deny (cancel install)",
+    "optDenyBuildDesc": "Run no build; cancel the install and clean up",
+    "buildDenied": "User denied the build — install cancelled, all traces cleaned up.",
+    "buildInstall": "Installing build dependencies ({bin}) ...",
+    "buildRun": "Running build (pnpm run build) ...",
+    "buildDone": "Build complete.",
+    "buildFail": "Build failed: {err}",
     "npmLocalDeps": "Detected {n} pnpm local-link dependencies ({names}) that npm cannot install — removed from the install manifest (runtime resolution is provided by the DSH host).",
     "copied": "Plugin package copied to {dest}",
     "patchExists": "Profile patch already has this plugin entry — skipping registration.",
@@ -613,9 +637,12 @@ function isTrustedRequest(req) {
   }
 }
 
-/** patch 中是否已有该包名的注册条目（行级精确匹配，避免前缀子串误判）。 */
+/** patch 中是否已有该包名的注册条目（行级精确匹配，避免前缀子串误判）。
+ *  scoped 包名（@scope/name）以 @ 开头，YAML plain scalar 不允许，必须加引号写入，
+ *  因此同时接受带单/双引号与不带引号的 name 行。 */
 function hasPatchEntry(patchText, pkgName) {
-  const pattern = new RegExp("^\\s*name:\\s*" + pkgName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\s*$", "m");
+  const escaped = pkgName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp("^\\s*name:\\s*(?:\"|')?" + escaped + "(?:\"|')?\\s*$", "m");
   return pattern.test(patchText);
 }
 
@@ -629,7 +656,10 @@ async function appendPatchEntry(entryId, pkgName) {
     const patch = await readFile(PATCH_FILE, "utf8").catch(() => "");
     if (hasPatchEntry(patch, pkgName)) return false;
     const trimmed = patch.trim();
-    const row = `    - id: ${entryId}\n      name: ${pkgName}\n`;
+    // scoped 包名（@scope/name）以 @ 开头，YAML plain scalar 不允许，必须加引号，
+    // 否则 loader 解析 cordis.patch.yml 直接失败、DSH 无法启动。
+    const quoted = /^[@!&*#?|>'"%`]/.test(pkgName) ? `"${pkgName}"` : pkgName;
+    const row = `    - id: ${entryId}\n      name: ${quoted}\n`;
     const next = trimmed === "" || trimmed === "[]"
       ? `# dsh-plugin-marketplace 自动注册的插件条目\n- insert:\n${row}`
       : patch.endsWith("\n") ? patch + "- insert:\n" + row : patch + "\n- insert:\n" + row;
@@ -828,7 +858,39 @@ async function fetchSearchRepos(kind = "dsh") {
 async function fetchAllRepos(kind = "dsh") {
   const collected = (await fetchRegistryRepos(kind)) ?? (await fetchSearchRepos(kind));
   collected.sort((a, b) => (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0));
-  return collected;
+  // pkg_name 冲突消解：同名 npm 包在 node_modules 的安装目标互斥（同目录互相覆盖），
+  // 列表并列会误导（如 dsh-archive-viewer 的 keepermttl/csiroqa 两个仓库显示两张卡）。
+  // 已安装的仓库优先保留（必须仍可见），否则保留 Star 高者。
+  return dedupeReposByPkgName(collected);
+}
+
+/**
+ * 运行时 pkg_name 冲突消解（纯函数）：同一 pkg_name 只保留一个条目——
+ * 已安装（isInstalled 命中）优先，其次 Star 高者；无 pkg_name 的条目按 full_name 天然唯一。
+ * 返回消解后的列表，被隐藏的 full_name 记入日志。
+ */
+function dedupeReposByPkgName(repos, isInstalled = (r) => installedMap.has(r.full_name)) {
+  const rank = (r) => (isInstalled(r) ? 1e12 + (r.stargazers_count ?? 0) : (r.stargazers_count ?? 0));
+  const byKey = new Map();
+  const dropped = [];
+  for (const r of repos) {
+    const key = r.pkg_name ? `pkg:${r.pkg_name}` : `repo:${r.full_name}`;
+    const prev = byKey.get(key);
+    if (!prev) {
+      byKey.set(key, r);
+      continue;
+    }
+    if (rank(r) > rank(prev)) {
+      dropped.push(prev.full_name);
+      byKey.set(key, r);
+    } else {
+      dropped.push(r.full_name);
+    }
+  }
+  if (dropped.length > 0) {
+    console.warn(`[dsh-plugin-marketplace] pkg_name 冲突，列表已隐藏：${dropped.join(", ")}（同名 npm 包只能安装一个，请原作者改名）`);
+  }
+  return [...byKey.values()];
 }
 
 /** 获取列表：缓存有效期内直接返回；并发请求共享同一次拉取；force 时忽略缓存强制刷新。kind 各自独立缓存。 */
@@ -900,6 +962,58 @@ async function npmInstallWithFallback(cacheDir, env, logLine, lang, allowScripts
     }
   }
   throw lastError;
+}
+
+/** 启动 pnpm（跨平台）：Windows 上 execFile 无法启动 .cmd 批处理，直接调 pnpm.cmd。 */
+async function runPnpm(args, opts) {
+  return await execFileAsync(process.platform === "win32" ? "pnpm.cmd" : "pnpm", args, opts);
+}
+
+/**
+ * 判断仓库是否需要先构建才能安装（纯逻辑 + 文件探测）：
+ * package.json 声明了 build 脚本，且加载入口（main / exports["./client"]）在仓库中缺失。
+ * 这类「只提交源码」的插件直接复制进 profile 会导致 DSH 启动失败（MODULE_NOT_FOUND）。
+ */
+async function needsPluginBuild(cacheDir) {
+  try {
+    const pkg = JSON.parse(await readFile(join(cacheDir, "package.json"), "utf8"));
+    if (!pkg || typeof pkg.scripts?.build !== "string" || !pkg.scripts.build.trim()) return false;
+    const targets = [];
+    if (typeof pkg.main === "string" && pkg.main.length > 0) targets.push(pkg.main);
+    const client = typeof pkg.exports?.["./client"] === "string"
+      ? pkg.exports["./client"]
+      : (typeof pkg.exports?.["./client"]?.default === "string" ? pkg.exports["./client"].default : null);
+    if (typeof client === "string" && client.length > 0) targets.push(client);
+    if (targets.length === 0) return false;
+    for (const target of targets) {
+      if (!(await exists(join(cacheDir, target)))) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 构建源码型插件（用户已确认）：pnpm-lock 存在用 pnpm（支持 link:/workspace: 协议），
+ * 否则 npm；均安装完整 devDependencies 后执行 build 脚本。失败抛错由安装流程统一清理。
+ */
+async function buildPluginPackage(cacheDir, env, logLine, lang) {
+  const usePnpm = await exists(join(cacheDir, "pnpm-lock.yaml"));
+  const bin = usePnpm ? "pnpm" : "npm";
+  logLine(t(lang, "buildInstall", { bin }));
+  if (usePnpm) {
+    await runPnpm(["install", "--no-frozen-lockfile"], { cwd: cacheDir, env, timeout: 600000 });
+  } else {
+    await runNpm(["install", "--no-audit", "--no-fund"], { cwd: cacheDir, env, timeout: 600000 });
+  }
+  logLine(t(lang, "buildRun"));
+  if (usePnpm) {
+    await runPnpm(["run", "build"], { cwd: cacheDir, env, timeout: 600000 });
+  } else {
+    await runNpm(["run", "build"], { cwd: cacheDir, env, timeout: 600000 });
+  }
+  return true;
 }
 
 async function scanRequirements(cacheDir) {
@@ -1199,6 +1313,35 @@ function apply(ctx) {
             return json(res, 200, { status: "aborted", repo, type, log });
           }
 
+          // 源码型插件确认：只提交源码（main / client bundle 缺失）的仓库必须先构建才能加载，
+          // 否则装完 DSH 直接无法启动（MODULE_NOT_FOUND / client bundle 缺失）。
+          // 构建会安装依赖并执行第三方构建脚本，执行前必须征求用户同意（拒绝则取消并清理）。
+          if (type === "cordis-plugin" && answers.__confirm_build__ === void 0) {
+            const needBuild = await needsPluginBuild(cacheDir);
+            if (needBuild) {
+              logLine(t(langFull, "buildDetected"));
+              return json(res, 200, {
+                status: "awaiting-input",
+                repo, type,
+                questions: [{
+                  id: "__confirm_build__",
+                  header: t(langFull, "qBuildHeader"),
+                  question: t(langFull, "qBuild", { repo }),
+                  options: [
+                    { value: "allow", label: t(langFull, "optAllowBuild"), description: t(langFull, "optAllowBuildDesc") },
+                    { value: "deny", label: t(langFull, "optDenyBuild"), description: t(langFull, "optDenyBuildDesc") }
+                  ]
+                }],
+                log
+              });
+            }
+          }
+          if (type === "cordis-plugin" && String(answers.__confirm_build__) === "deny") {
+            if (cacheDir) await rm(cacheDir, { recursive: true, force: true }).catch(() => {});
+            logLine(t(langFull, "buildDenied"));
+            return json(res, 200, { status: "aborted", repo, type, log });
+          }
+
           // 手动安装确认：仓库不含 SKILL.md / agent 预设 / 安装脚本 / 插件清单（如 awesome 聚合页），
           // 无法一键安装——弹窗展示 README 摘要与仓库链接，由用户自行处理。
           if (type === "instructions" && answers.__confirm_manual__ === void 0) {
@@ -1339,7 +1482,14 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
     if (!resolve(dest).startsWith(resolve(PROFILE_NM) + sep)) {
       throw new Error(`目标路径越界: ${dest}（拒绝安装）`);
     }
-    if (Object.keys(deps).length > 0) {
+    // 源码型插件（用户已确认构建）：构建先行——完整安装依赖（含 devDependencies）并执行
+    // build 脚本，产物随复制一并进入 profile；构建流程已覆盖运行时依赖，跳过单独安装。
+    const shouldBuild = String(answers.__confirm_build__) === "allow";
+    if (shouldBuild) {
+      await buildPluginPackage(cacheDir, env, logLine, lang);
+      logLine(t(lang, "buildDone"));
+    }
+    if (!shouldBuild && Object.keys(deps).length > 0) {
       logLine(t(lang, "deps", { n: Object.keys(deps).length }));
       const allowScripts = String(answers.__confirm_npm_scripts__) === "allow";
       if (allowScripts) logLine(t(lang, "npmScriptsAllowed"));
@@ -1363,4 +1513,4 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, hasPatchEntry, normalizeRepo, appendPatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, hasPatchEntry, normalizeRepo, appendPatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, needsPluginBuild, dedupeReposByPkgName };

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-08-14T05:41:30.570Z",
-  "count": 997,
+  "count": 996,
   "source": "full",
   "repos": [
     {
@@ -17241,26 +17241,6 @@
       "license": "MIT",
       "registry_seen_at": "2026-08-14T05:41:07.255Z",
       "pkg_name": "dsh-skin"
-    },
-    {
-      "full_name": "csiroqa/dsh-archive-viewer",
-      "name": "dsh-archive-viewer",
-      "description": "DeepSeek Harness（DSH）归档增强插件：自动定期归档、文件夹归档整理、LLM 摘要沉淀经验库、会话收藏与便签、会话删除与优雅关机。Archive enhancement plugin for DeepSeek Harness: auto-archive, folder organization, LLM knowledge library, bookmarks & notes, session delete.",
-      "html_url": "https://github.com/csiroqa/dsh-archive-viewer",
-      "stargazers_count": 0,
-      "updated_at": "2026-08-13T23:26:05Z",
-      "default_branch": "main",
-      "topics": [
-        "archive",
-        "cordis",
-        "deepseek-harness",
-        "dsh",
-        "dsh-plugin",
-        "knowledge-library"
-      ],
-      "license": "MIT",
-      "registry_seen_at": "2026-08-14T05:41:07.255Z",
-      "pkg_name": "@dsh-external/dsh-archive-viewer"
     },
     {
       "full_name": "STARDUSTLC666/dsh-dingtalk",

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -153,6 +153,34 @@ export function shouldInheritProbe(repo, old) {
   return Boolean(old && old.updated_at === repo.updated_at && typeof old.has_skill === "boolean");
 }
 
+/**
+ * pkg_name 冲突消解（纯函数）：同名 npm 包在 node_modules 的安装目标互斥（同目录互相覆盖），
+ * 索引并列会误导（显示两张卡、装一个盖掉另一个）。保留 Star 高者，低者移入 dropped。
+ * 无 pkg_name 的条目按 full_name 天然唯一，不参与冲突。
+ * @returns {{ repos: Array, dropped: string[] }} dropped 为被隐藏条目的 full_name 列表。
+ */
+export function dedupeByPkgName(repos) {
+  const byKey = new Map();
+  const dropped = [];
+  for (const r of repos) {
+    const key = r.pkg_name ? `pkg:${r.pkg_name}` : `repo:${r.full_name}`;
+    const prev = byKey.get(key);
+    if (!prev) {
+      byKey.set(key, r);
+      continue;
+    }
+    const prevStars = prev.stargazers_count ?? 0;
+    const curStars = r.stargazers_count ?? 0;
+    if (curStars > prevStars) {
+      dropped.push(prev.full_name);
+      byKey.set(key, r);
+    } else {
+      dropped.push(r.full_name);
+    }
+  }
+  return { repos: [...byKey.values()], dropped };
+}
+
 /** 探测单个仓库（Trees API 一次调用同时拿到 has_skill / has_install_script）。失败容忍：null 表示未知。 */
 async function probeRepo(repo) {
   const url = `https://api.github.com/repos/${repo.full_name}/git/trees/${repo.default_branch}?recursive=1`;
@@ -260,7 +288,7 @@ async function main() {
     if (Date.parse(seenAt) < now - STALE_DAYS * 24 * 3600 * 1000) continue;
     merged.set(r.full_name, { ...r, registry_seen_at: seenAt });
   }
-  const repos = [...merged.values()].sort((a, b) => (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0));
+  let repos = [...merged.values()].sort((a, b) => (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0));
 
   // skills 模式：增量继承（控额度的命根子）+ Trees 探测
   if (MODE === "skills") {
@@ -292,6 +320,17 @@ async function main() {
   } else {
     await enrichPkgNames(repos);
   }
+
+  // pkg_name 冲突消解：同名 npm 包在 node_modules 里的安装目标互斥（同目录互相覆盖），
+  // 索引里并列会误导用户（显示两张卡、装一个盖掉另一个，如 dsh-archive-viewer 的
+  // keepermttl/csiroqa 两个仓库）。保留 Star 高者，低者从索引剔除并告警维护者改名。
+  const { repos: deduped, dropped: droppedRepos } = dedupeByPkgName(repos);
+  if (droppedRepos.length > 0) {
+    for (const fullName of droppedRepos) {
+      log(`pkg_name 冲突：隐藏低 Star 条目 ${fullName}（同名 npm 包只能安装一个，请原作者改名）`);
+    }
+  }
+  repos = deduped;
 
   const out = {
     generated_at: new Date().toISOString(),

--- a/scripts/smoke-tests.mjs
+++ b/scripts/smoke-tests.mjs
@@ -1,7 +1,10 @@
 // 冒烟测试：验证安全加固与纯函数修复（R1 Host 白名单 / R2 env 最小化 / n3 版本比较等）。
 // 运行：node scripts/smoke-tests.mjs（CI 的 syntax check 步骤同步执行）
-import { compareVersions, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, looksLikeDshPlugin } from "../lib/index.js";
-import { classifyTree, shouldInheritProbe } from "./build-registry.mjs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { compareVersions, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, looksLikeDshPlugin, dedupeReposByPkgName, needsPluginBuild, hasPatchEntry } from "../lib/index.js";
+import { classifyTree, shouldInheritProbe, dedupeByPkgName } from "./build-registry.mjs";
 
 let pass = 0, fail = 0;
 function check(name, actual, expected) {
@@ -103,6 +106,59 @@ check("无依赖无字段 → 非插件", looksLikeDshPlugin({ name: "x" }), fal
 check("空对象 → 非插件", looksLikeDshPlugin({}), false);
 check("null → 未知", looksLikeDshPlugin(null), null);
 check("非对象 → 未知", looksLikeDshPlugin("str"), null);
+
+// ---- pkg_name 冲突消解（build-registry.mjs，生成索引时去重）----
+check("pkg_name 冲突保留高 Star", dedupeByPkgName([
+  { full_name: "a/x", pkg_name: "shared", stargazers_count: 1 },
+  { full_name: "b/x", pkg_name: "shared", stargazers_count: 5 }
+]).repos.map((r) => r.full_name), ["b/x"]);
+check("pkg_name 冲突 dropped 记录低 Star 者", dedupeByPkgName([
+  { full_name: "a/x", pkg_name: "shared", stargazers_count: 1 },
+  { full_name: "b/x", pkg_name: "shared", stargazers_count: 5 }
+]).dropped, ["a/x"]);
+check("无 pkg_name 条目不参与冲突", dedupeByPkgName([
+  { full_name: "a/x", pkg_name: null, stargazers_count: 1 },
+  { full_name: "b/x", pkg_name: null, stargazers_count: 5 }
+]).repos.length, 2);
+
+// ---- pkg_name 冲突消解（运行时 lib/index.js，列表展示时去重）----
+const dupRepos = [
+  { full_name: "a/lo", pkg_name: "shared", stargazers_count: 2 },
+  { full_name: "b/hi", pkg_name: "shared", stargazers_count: 10 },
+  { full_name: "c/solo", pkg_name: null, stargazers_count: 0 }
+];
+check("运行时默认保留 Star 高者", dedupeReposByPkgName(dupRepos).map((r) => r.full_name), ["b/hi", "c/solo"]);
+check("运行时已安装优先保留", dedupeReposByPkgName(dupRepos, (r) => r.full_name === "a/lo").map((r) => r.full_name), ["a/lo", "c/solo"]);
+
+// ---- needsPluginBuild（只提交源码、缺构建产物的插件判定）----
+const tmpSmoke = mkdtempSync(join(tmpdir(), "dsh-mp-smoke-"));
+try {
+  const srcOnly = join(tmpSmoke, "src-only");
+  mkdirSync(srcOnly);
+  writeFileSync(join(srcOnly, "package.json"), JSON.stringify({
+    name: "x",
+    main: "lib/index.js",
+    scripts: { build: "tsdown" },
+    exports: { "./client": { default: "./lib/client.js" } }
+  }));
+  check("main 缺失 → 需要构建", await needsPluginBuild(srcOnly), true);
+  mkdirSync(join(srcOnly, "lib"));
+  writeFileSync(join(srcOnly, "lib/index.js"), "//x");
+  writeFileSync(join(srcOnly, "lib/client.js"), "//x");
+  check("产物齐全 → 无需构建", await needsPluginBuild(srcOnly), false);
+  writeFileSync(join(srcOnly, "package.json"), JSON.stringify({ name: "x", main: "lib/index.js" }));
+  check("无 build 脚本 → 无需构建", await needsPluginBuild(srcOnly), false);
+  writeFileSync(join(srcOnly, "package.json"), JSON.stringify({ name: "x", scripts: { build: "tsdown" } }));
+  check("无 main/client 入口 → 无需构建", await needsPluginBuild(srcOnly), false);
+} finally {
+  rmSync(tmpSmoke, { recursive: true, force: true });
+}
+
+// ---- hasPatchEntry（scoped 包名引号兼容）----
+check("引号形式命中", hasPatchEntry('  - insert:\n    - id: x\n      name: "@a/b"\n', "@a/b"), true);
+check("无引号形式命中", hasPatchEntry('      name: @a/b\n', "@a/b"), true);
+check("不同包名不命中", hasPatchEntry('      name: other\n', "@a/b"), false);
+check("前缀子串不误伤", hasPatchEntry('      name: @a/bc\n', "@a/b"), false);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## 问题

1. 市场列表对 `pkg_name` 相同的仓库（如 `keepermttl/dsh-archive-viewer` 与 `csiroqa/dsh-archive-viewer`）不去重：显示两张卡、未安装的也误标为「已安装」，且两个包装进 node_modules 会互相覆盖。
2. 只提交源码的插件（main / client bundle 缺失，如 dsh-archive-viewer）被直接复制进 profile：cordis 加载报 MODULE_NOT_FOUND、client bundle 缺失 → DSH 无法启动。
3. 注册 scoped 包名（`@scope/name`）时写入无引号 YAML：以 `@` 开头的 plain scalar 违反 YAML 规范，loader 解析 cordis.patch.yml 直接失败。

## 修复

- `lib/index.js`：
  - 列表时按 `pkg_name` 去重（已安装优先，其次 Star 高者）
  - 新增 `needsPluginBuild` 检测源码型插件，安装时询问用户，允许则先 `pnpm install && pnpm run build`（存在 pnpm-lock.yaml 时用 pnpm）再安装，拒绝则取消并清理
  - `appendPatchEntry` 对 `@` 等 YAML 保留字符开头的包名自动加引号；`hasPatchEntry` 兼容引号形式，避免重装重复追加注册行
- `registry.json`：移除重复条目 `csiroqa/dsh-archive-viewer`（997 → 996）
- `scripts/build-registry.mjs`：新增 `dedupeByPkgName`，生成索引时按包名保留高 Star 仓库
- `scripts/smoke-tests.mjs`：补充去重、构建判定、引号匹配的测试

## 验证

- 冒烟测试 83/83 通过（`node scripts/smoke-tests.mjs`）
- dsh-archive-viewer 按新流程构建后可正常加载，DSH 正常启动
