### PR TITLE
fix: run pnpm via cmd.exe on Windows (spawn EINVAL)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -933,9 +933,16 @@ async function runNpm(args, opts) {
   return await execFileAsync("npm", args, opts);
 }
 
-/** 启动 pnpm（跨平台）：Windows 上 execFile 无法启动 .cmd 批处理，直接调 pnpm.cmd。 */
+/**
+ * 启动 pnpm（跨平台）。Windows 上 Node 的 execFile 无法直接启动 .cmd 批处理
+ * （即使 pnpm 已安装也无条件抛 spawn EINVAL），需经 cmd.exe 解析 PATH 中的 pnpm 启动；
+ * 非 Windows 直接调用 pnpm。
+ */
 async function runPnpm(args, opts) {
-  return await execFileAsync(process.platform === "win32" ? "pnpm.cmd" : "pnpm", args, opts);
+  if (process.platform === "win32") {
+    return await execFileAsync("cmd.exe", ["/d", "/s", "/c", "pnpm", ...args], opts);
+  }
+  return await execFileAsync("pnpm", args, opts);
 }
 
 /** 递归收集 exports 子树中的全部字符串入口（覆盖 default/import/require/browser 等条件与嵌套对象）。 */


### PR DESCRIPTION
## 问题

PR #3 合入的源码型插件构建流程（`buildPluginPackage` → `runPnpm`）在 Windows 上不可用：

Node 的 `child_process.execFile` 无法直接启动 `.cmd` 批处理——即使 pnpm 已安装，也会无条件抛 `spawn EINVAL`。`runPnpm` 的 win32 分支调用 `execFileAsync("pnpm.cmd", ...)`，导致任何走 pnpm 构建的仓库（存在 `pnpm-lock.yaml`）在 Windows 上一启动就失败。

本仓库 `runNpm` 的注释早已记录同一问题（`spawn npm.cmd EINVAL`），因此 `runNpm` 用 `node + npm-cli.js` 绕开 `.cmd` 启动；`runPnpm` 却沿用了同一条不可用的路径。

## 修复

Windows 分支改为经 `cmd.exe /d /s /c pnpm ...` 启动（由 cmd 解析 PATH 中的 `pnpm.cmd`），非 Windows 平台不变。

## 验证

- `node --check lib/index.js` 通过
- 冒烟测试 121/121 通过
- 真实调用验证（Windows）：`execFile('cmd.exe', ['/d','/s','/c','pnpm','--version'])` → `11.7.0`；同环境下 `execFile('pnpm.cmd', ['--version'])` → `spawn EINVAL`（复现原问题）
