### PR TITLE
fix: 声明 webServer 依赖注入——修复 dsh web 插件树加载失败（核心修复）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,9 @@ const execFileAsync = promisify(execFile);
 const requireFromHere = createRequire(import.meta.url);
 
 export const name = "dsh-plugin-marketplace";
+/** 声明依赖 webServer 服务：cordis 会先启动该服务再执行 apply()，
+ *  避免 ctx.get("webServer") 同步取值为 undefined 导致插件树加载失败 */
+export const inject = ["webServer"];
 
 const DSH_HOME = process.env.DSH_HOME ?? join(homedir(), ".dsh");
 const MARKET_ROOT = join(DSH_HOME, "marketplace");


### PR DESCRIPTION
## 问题

`dsh web` 启动时插件树加载失败：

```
Error: dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include): dsh-plugin-marketplace: webServer service unavailable
```

原因：插件在 `apply()` 中同步调用 `ctx.get("webServer")`，但未声明对 `webServer` 服务的依赖注入——cordis 不保证该服务先于插件启动，存在竞态。

## 修复

- `lib/index.js`: 导出 `export const inject = ["webServer"]`，声明依赖后 cordis 保证服务先启动

## 验证

- `node --check lib/index.js` 通过
- `dsh web` 启动正常，marketplace 插件树加载成功

按 review 建议拆分：本 PR 仅含核心修复（3 行）；测试金字塔/覆盖率/Hook/文档体系另开 PR 分批评审。
