### PR TITLE
perf: 分页懒加载插件列表，解决打开时可能出现的卡顿

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -40,6 +40,23 @@ window.__ModuleLoader__.load({
       dataSourceSearch: "⚠ 网络索引源不可用，当前为搜索兜底结果（不完整）",
       dataSourceBundled: "当前显示插件内置索引（离线可用；点「刷新」获取最新）",
       dedupeHint: "{n} 个同名包已隐藏（同名 npm 包只能安装一个）",
+      backupTitle: "备份与恢复",
+      backupExport: "导出备份",
+      backupImport: "导入并恢复",
+      backupWebdavUrl: "WebDAV 地址",
+      backupWebdavUser: "用户名",
+      backupWebdavPass: "密码",
+      backupWebdavPush: "备份到 WebDAV",
+      backupWebdavPull: "从 WebDAV 恢复",
+      backupDownloadOk: "备份已导出（JSON 文件）",
+      backupRestoreStart: "开始恢复 {n} 个插件（逐个走安装流程）…",
+      backupRestoreDone: "备份恢复完成 ✔",
+      backupRestoreErr: "恢复失败: {err}",
+      backupBadFile: "备份文件格式不正确",
+      backupNote: "备份含安装记录（仓库/类型/版本），不含密钥（环境变量从不持久化）",
+      cliHintLabel: "README 官方安装指令",
+      cliHintCopy: "复制",
+      cliHintCopied: "已复制 ✔",
       updatedAt: "更新于 {d}",
       githubLink: "Github原链",
       tags: "标签: {tags}",
@@ -121,6 +138,23 @@ window.__ModuleLoader__.load({
       dataSourceSearch: "⚠ index sources unreachable — showing partial search results",
       dataSourceBundled: "Showing the bundled index (offline-ready; click Refresh for the latest)",
       dedupeHint: "{n} duplicate packages hidden (same npm package can only be installed once)",
+      backupTitle: "Backup & Restore",
+      backupExport: "Export backup",
+      backupImport: "Import & restore",
+      backupWebdavUrl: "WebDAV URL",
+      backupWebdavUser: "Username",
+      backupWebdavPass: "Password",
+      backupWebdavPush: "Backup to WebDAV",
+      backupWebdavPull: "Restore from WebDAV",
+      backupDownloadOk: "Backup exported (JSON file)",
+      backupRestoreStart: "Restoring {n} plugins (one by one through the install flow)…",
+      backupRestoreDone: "Backup restore complete ✔",
+      backupRestoreErr: "Restore failed: {err}",
+      backupBadFile: "Invalid backup file",
+      backupNote: "Backup holds install records (repo/type/version); secrets are never persisted, so nothing sensitive is included",
+      cliHintLabel: "Official CLI install command (from README)",
+      cliHintCopy: "Copy",
+      cliHintCopied: "Copied ✔",
       updatedAt: "updated {d}",
       githubLink: "GitHub repo",
       tags: "Tags: {tags}",
@@ -321,6 +355,8 @@ window.__ModuleLoader__.load({
       var inst = props.inst;
       var inputValues = props.inputValues;
       var setInputValues = props.setInputValues;
+      // README CLI 指令复制反馈（顶层声明，遵守 hooks 调用顺序）
+      var copyState = useState(false); var copied = copyState[0]; var setCopied = copyState[1];
       if (inst.phase === "input") {
         var hasTextQuestion = inst.questions.some(function (q) { return !(q.options && q.options.length > 0); });
         return h("div", { id: "dshm-install-panel", style: s.panel },
@@ -378,6 +414,31 @@ window.__ModuleLoader__.load({
             ? (inst.result.type === "skill" ? t("doneSkills", { count: inst.result.count }) : t("donePlugins", { count: inst.result.count }))
             : t("doneMsg", { type: inst.result.type })) + (inst.result.location ? t("doneMsgLoc", { loc: inst.result.location }) : "")),
         inst.result && (inst.result.status === "manual") && h("p", { style: s.err }, linkify(t("manualMsg", { url: inst.result.url || "" }))),
+        inst.result && inst.result.cliCommand ? (function () {
+          // README 官方 CLI 安装指令：显示 + 一键复制（navigator.clipboard 不可用时降级 execCommand）
+          function copyCmd() {
+            var text = inst.result.cliCommand;
+            function fallback() {
+              var ta = document.createElement("textarea");
+              ta.value = text;
+              document.body.appendChild(ta);
+              ta.select();
+              try { document.execCommand("copy"); setCopied(true); } catch (e) { /* ignore */ }
+              ta.remove();
+            }
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(text).then(function () { setCopied(true); }, fallback);
+            } else fallback();
+            setTimeout(function () { setCopied(false); }, 2000);
+          }
+          return h("div", { style: { margin: "10px 0 0", padding: "10px 12px", borderRadius: 8, background: "var(--dsw-alias-bg-base)", border: "1px solid var(--dsw-alias-border-l2)" } },
+            h("div", { style: { display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 } },
+              h("span", { style: { fontSize: 12, color: "var(--dsw-alias-label-secondary)", fontWeight: 600 } }, t("cliHintLabel")),
+              h("button", { className: "dshm-btn", style: Object.assign({}, s.btn, { padding: "2px 10px", fontSize: 12 }), onClick: copyCmd }, copied ? t("cliHintCopied") : t("cliHintCopy"))
+            ),
+            h("code", { style: { display: "block", marginTop: 6, fontSize: 12, color: "var(--dsw-alias-label-primary)", wordBreak: "break-all", userSelect: "all" } }, inst.result.cliCommand)
+          );
+        })() : null,
         inst.result && (inst.result.status === "aborted") && h("p", { style: s.err }, t("abortedMsg")),
         inst.result && (inst.result.status === "failed") && h("p", { style: s.err }, t("failedMsg", { err: (inst.result.error || "unknown") })),
         inst.phase !== "running" ? h("button", { className: "dshm-btn", style: Object.assign({}, s.btn, { marginTop: 12 }), onClick: props.cancel }, t("backToList")) : h("button", { className: "dshm-btn", style: Object.assign({}, s.btn, { marginTop: 12 }), onClick: props.cancel }, t("cancelRunning"))
@@ -491,61 +552,73 @@ window.__ModuleLoader__.load({
       );
     }
 
-    /** 通用 Skills tab：全量索引 + 分页（每页 60，IntersectionObserver 触底加载）。 */
-    var SKILL_PAGE_SIZE = 60;
+    /** 通用 Skills tab：服务端分页（每页 100，#14），搜索下推服务端，触底加载下一页。 */
+    var SKILL_PAGE_SIZE = 100;
+    var skillsFetchSeq = 0; // 模块级请求序号：查询/刷新/翻页竞态时丢弃过期响应
+    /** 备份恢复队列（模块级，单市场实例）：逐项走正常安装流程，awaiting-input 弹窗期间自动暂停。 */
+    var restoreState = { list: null, idx: 0 };
     function SkillsTab(props) {
       var state = useState(null); var repos = state[0]; var setRepos = state[1];
       var state2 = useState(null); var error = state2[0]; var setError = state2[1];
       var state3 = useState(""); var query = state3[0]; var setQuery = state3[1];
-      var state4 = useState(SKILL_PAGE_SIZE); var visible = state4[0]; var setVisible = state4[1];
+      var state4 = useState(1); var page = state4[0]; var setPage = state4[1];
       var state5 = useState(""); var dataSource = state5[0]; var setDataSource = state5[1];
       var state6 = useState(0); var dropped = state6[0]; var setDropped = state6[1];
+      var state7 = useState(0); var total = state7[0]; var setTotal = state7[1];
+      var state8 = useState(false); var loading = state8[0]; var setLoading = state8[1];
+
+      function fetchPage(pg, q, refresh) {
+        var mySeq = ++skillsFetchSeq;
+        setLoading(true);
+        fetch("/api/marketplace/skills?lang=" + langCurrent + "&page=" + pg + "&pageSize=" + SKILL_PAGE_SIZE + "&q=" + encodeURIComponent(q || "") + (refresh ? "&refresh=1" : ""), { headers: { "X-DSH-Marketplace": "1" } })
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            if (mySeq !== skillsFetchSeq) return; // 已被更新的请求取代
+            if (data.error) { setError(data.error); setLoading(false); }
+            else {
+              setRepos(function (prev) {
+                if (pg === 1) return data.repos || [];
+                var seen = {};
+                (prev || []).forEach(function (r) { seen[r.full_name] = true; });
+                return (prev || []).concat((data.repos || []).filter(function (r) { if (seen[r.full_name]) return false; seen[r.full_name] = true; return true; }));
+              });
+              setPage(pg);
+              setTotal(data.total != null ? data.total : (data.repos || []).length);
+              setDataSource(data.source || "");
+              setDropped(data.dropped || 0);
+              setError(null);
+              setLoading(false);
+            }
+          })
+          .catch(function (err) { if (mySeq === skillsFetchSeq) { setError(String(err)); setLoading(false); } });
+      }
 
       function doRefresh(force) {
         props.showToast(t("refreshing"), true);
-        fetch("/api/marketplace/skills?lang=" + langCurrent + (force ? "&refresh=1" : ""), { headers: { "X-DSH-Marketplace": "1" } }).then(function (r) { return r.json(); }).then(function (data) {
-          if (data.error) { setError(data.error); props.showToast(t("refreshFail", { err: data.error }), false); }
-          else { setRepos(data.repos || []); setVisible(SKILL_PAGE_SIZE); setDataSource(data.source || ""); setDropped(data.dropped || 0); props.showToast(t("refreshOk", { n: (data.repos || []).length }), true); }
-        }).catch(function (err) {
-          props.showToast(t("refreshFail", { err: String(err) }), false);
-        });
+        fetchPage(1, query, true);
       }
 
-      useEffect(function () {
-        var cancelled = false;
-        setError(null);
-        fetch("/api/marketplace/skills?lang=" + langCurrent, { headers: { "X-DSH-Marketplace": "1" } }).then(function (r) { return r.json(); }).then(function (data) {
-          if (cancelled) return;
-          if (data.error) { setError(data.error); setRepos([]); }
-          else { setRepos(data.repos || []); setVisible(SKILL_PAGE_SIZE); setDataSource(data.source || ""); setDropped(data.dropped || 0); }
-        }).catch(function (err) { if (!cancelled) { setError(String(err)); setRepos([]); } });
-        return function () { cancelled = true; };
-      }, [props.tick]);
+      // 初始加载 / 外部 tick（安装卸载后刷新第一页）
+      useEffect(function () { fetchPage(1, "", false); }, [props.tick]);
+      // 搜索词变化 → 重置并加载第 1 页（搜索已下推服务端）
+      useEffect(function () { fetchPage(1, query, false); }, [query]);
 
-      // 搜索词变化时重置分页（搜索在完整数组 filter 后重新分页）
-      useEffect(function () { setVisible(SKILL_PAGE_SIZE); }, [query]);
-
-      // 触底加载：sentinel 进入视口 → 追加一页
+      // 触底加载：sentinel 进入视口且未加载完 → 下一页
       useEffect(function () {
         var el = document.getElementById("dshm-skills-sentinel");
         if (!el) return;
         var observer = new IntersectionObserver(function (entries) {
           entries.forEach(function (entry) {
-            if (entry.isIntersecting) setVisible(function (n) { return n + SKILL_PAGE_SIZE; });
+            if (entry.isIntersecting && !loading && repos && repos.length < total) {
+              fetchPage(page + 1, query, false);
+            }
           });
         }, { rootMargin: "300px" });
         observer.observe(el);
         return function () { observer.disconnect(); };
-      }, [repos, query]);
+      }, [repos, query, total, loading]);
 
       var q = query.trim().toLowerCase();
-      var list = q
-        ? (repos || []).filter(function (r) {
-            return (r.name + " " + r.full_name + " " + (r.topics || []).join(" ")).toLowerCase().indexOf(q) !== -1;
-          })
-        : (repos || []);
-      var shown = list.slice(0, visible);
-      var hasMore = shown.length < list.length;
 
       return h("div", null,
         h("div", { style: s.head },
@@ -570,15 +643,15 @@ window.__ModuleLoader__.load({
         repos === null ? h("p", { style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("loading")) : null,
         repos ? [
           h("p", { key: "count", style: Object.assign({}, s.meta, { margin: "0 0 8px" }) },
-            t("countSkills", { n: repos.length }) + (q ? t("countMatch", { n: list.length }) : "")),
+            t("countSkills", { n: total }) + (q ? t("countMatch", { n: total }) : "")),
           dropped > 0 ? h("p", { key: "dedupe", style: s.srcHint }, t("dedupeHint", { n: dropped })) : null,
-          shown.map(function (repo) {
+          repos.map(function (repo) {
             return h(RepoCard, { key: repo.full_name, repo: repo, installed: repo.installed, updateAvailable: false, busy: !!(props.inst && props.inst.phase === "running"), selfBusy: !!(props.inst && props.inst.phase === "running" && props.inst.repo === repo.full_name), uninstalling: props.uninstalling, onUninstall: props.onUninstall, onInstall: function (fullName) { props.setInputValues({}); props.runInstall(fullName, {}, []); } });
           }),
-          hasMore ? h("div", { key: "sentinel", id: "dshm-skills-sentinel", style: { height: 1 } }) : null,
-          list.length === 0 ? h("p", { key: "empty", style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("noMatch", { q: query })) : null
+          repos.length < total && !loading ? h("div", { key: "sentinel", id: "dshm-skills-sentinel", style: { height: 1 } }) : null,
+          repos.length === 0 && !loading ? h("p", { key: "empty", style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("noMatch", { q: query })) : null
         ] : null,
-        repos && repos.length === 0 && !error ? h("p", { style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("skillsEmpty")) : null
+        repos && repos.length === 0 && !error && !loading ? h("p", { style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("skillsEmpty")) : null
       );
     }
 
@@ -644,12 +717,21 @@ window.__ModuleLoader__.load({
           // 安装结束（非等待输入）：两个 tab 都重新拉取列表——服务端实时标注 installed，
           // 安装成功的卡片自动变「已安装」并置顶，无需本地拼装状态
           if (data.status !== "awaiting-input") setTick(tick + 1);
+          // 备份恢复队列推进（manual/aborted 也继续下一个，避免卡死）
+          if (data.status !== "awaiting-input" && restoreState.list) {
+            restoreState.idx++;
+            nextRestore();
+          }
         }).catch(function (err) {
           setInst(function (prev) {
             if (!prev || prev.repo !== repo) return prev;
             return { repo: repo, phase: "failed", log: (prev.log || []).concat([t("requestFail", { err: String(err) })]), questions: [], answers: answers || {}, result: null };
           });
           setTick(tick + 1);
+          if (restoreState.list) {
+            restoreState.idx++;
+            nextRestore();
+          }
         });
       }
 
@@ -702,6 +784,94 @@ window.__ModuleLoader__.load({
         setToast({ text: text, ok: !!ok });
       }
 
+      // ---- 备份 / 恢复（#15）----
+      var wdState1 = useState(""); var wdUrl = wdState1[0]; var setWdUrl = wdState1[1];
+      var wdState2 = useState(""); var wdUser = wdState2[0]; var setWdUser = wdState2[1];
+      var wdState3 = useState(""); var wdPass = wdState3[0]; var setWdPass = wdState3[1];
+
+      function nextRestore() {
+        if (!restoreState.list) return;
+        if (restoreState.idx >= restoreState.list.length) {
+          restoreState.list = null;
+          showToast(t("backupRestoreDone"), true);
+          setTick(tick + 1);
+          return;
+        }
+        runInstall(restoreState.list[restoreState.idx], {}, []);
+      }
+
+      function startRestore(repoList) {
+        if (restoreState.list) return; // 已在恢复中
+        if (!Array.isArray(repoList) || repoList.length === 0) return;
+        restoreState.list = repoList;
+        restoreState.idx = 0;
+        showToast(t("backupRestoreStart", { n: repoList.length }), true);
+        nextRestore();
+      }
+
+      function exportBackup() {
+        fetch("/api/marketplace/backup", { headers: { "X-DSH-Marketplace": "1" } })
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            if (data.error || !data.backup) { showToast(data.error || t("backupRestoreErr", { err: "empty" }), false); return; }
+            var blob = new Blob([JSON.stringify(data.backup, null, 2)], { type: "application/json" });
+            var a = document.createElement("a");
+            a.href = URL.createObjectURL(blob);
+            a.download = "dsh-marketplace-backup-" + new Date().toISOString().slice(0, 10) + ".json";
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(a.href);
+            showToast(t("backupDownloadOk"), true);
+          })
+          .catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
+      }
+
+      function importBackupFile(file) {
+        if (!file || restoreState.list) return;
+        var reader = new FileReader();
+        reader.onload = function () {
+          var backup;
+          try { backup = JSON.parse(String(reader.result)); } catch (e) { showToast(t("backupBadFile"), false); return; }
+          fetch("/api/marketplace/restore/diff", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-DSH-Marketplace": "1" },
+            body: JSON.stringify({ backup: backup })
+          }).then(function (r) { return r.json(); }).then(function (data) {
+            if (data.error) { showToast(data.error, false); return; }
+            showToast((data.log || []).join(" ") || t("backupRestoreDone"), true);
+            if (Array.isArray(data.missing) && data.missing.length > 0) startRestore(data.missing);
+          }).catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
+        };
+        reader.readAsText(file);
+      }
+
+      function webdavPush() {
+        if (restoreState.list) return;
+        fetch("/api/marketplace/backup/webdav", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-DSH-Marketplace": "1" },
+          body: JSON.stringify({ url: wdUrl.trim(), username: wdUser.trim(), password: wdPass })
+        }).then(function (r) { return r.json(); }).then(function (data) {
+          showToast((data.log || []).join(" ") || (data.error || t("backupRestoreErr", { err: "webdav" })), data.status === "done");
+        }).catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
+      }
+
+      function webdavPull() {
+        if (restoreState.list) return;
+        fetch("/api/marketplace/restore/webdav", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-DSH-Marketplace": "1" },
+          body: JSON.stringify({ url: wdUrl.trim(), username: wdUser.trim(), password: wdPass })
+        }).then(function (r) { return r.json(); }).then(function (data) {
+          if (data.error) { showToast(data.error, false); return; }
+          showToast((data.log || []).join(" ") || t("backupRestoreDone"), true);
+          if (Array.isArray(data.missing) && data.missing.length > 0) startRestore(data.missing);
+        }).catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
+      }
+
+      var wdInputStyle = Object.assign({}, s.input, { width: 150, marginTop: 0 });
+
       var tabProps = { inst: inst, runInstall: runInstall, setInputValues: setInputValues, tick: tick, showToast: showToast, uninstalling: uninstallingRepo, onUninstall: uninstallPlugin };
 
       return h("div", { style: s.page },
@@ -710,6 +880,20 @@ window.__ModuleLoader__.load({
         h("div", { style: s.tabBar },
           h("button", { style: activeTab === "plugins" ? s.tabActive : s.tabBtn, onClick: function () { setActiveTab("plugins"); } }, t("tabPlugins")),
           h("button", { style: activeTab === "skills" ? s.tabActive : s.tabBtn, onClick: function () { setActiveTab("skills"); } }, t("tabSkills"))
+        ),
+        h("div", { key: "backup", style: { border: "1px solid var(--dsw-alias-border-l2)", borderRadius: 10, padding: "10px 14px", margin: "0 0 12px" } },
+          h("p", { style: { fontSize: 12, fontWeight: 600, margin: "0 0 8px", color: "var(--dsw-alias-label-secondary)" } }, t("backupTitle")),
+          h("div", { style: { display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" } },
+            h("button", { className: "dshm-btn", style: s.btn, onClick: exportBackup }, t("backupExport")),
+            h("button", { className: "dshm-btn", style: s.btn, onClick: function () { var el = document.getElementById("dshm-backup-file"); if (el) el.click(); } }, t("backupImport")),
+            h("input", { id: "dshm-backup-file", type: "file", accept: ".json,application/json", style: { display: "none" }, onChange: function (e) { importBackupFile(e.target.files && e.target.files[0]); e.target.value = ""; } }),
+            h("input", { style: wdInputStyle, placeholder: t("backupWebdavUrl"), value: wdUrl, onChange: function (e) { setWdUrl(e.target.value); } }),
+            h("input", { style: Object.assign({}, wdInputStyle, { width: 100 }), placeholder: t("backupWebdavUser"), value: wdUser, onChange: function (e) { setWdUser(e.target.value); } }),
+            h("input", { style: Object.assign({}, wdInputStyle, { width: 100 }), type: "password", placeholder: t("backupWebdavPass"), value: wdPass, onChange: function (e) { setWdPass(e.target.value); } }),
+            h("button", { className: "dshm-btn", style: s.btn, onClick: webdavPush }, t("backupWebdavPush")),
+            h("button", { className: "dshm-btn", style: s.btn, onClick: webdavPull }, t("backupWebdavPull"))
+          ),
+          h("p", { style: { fontSize: 11, color: "var(--dsw-alias-label-tertiary)", margin: "6px 0 0" } }, t("backupNote"))
         ),
         inst ? h("div", { style: s.installOverlay }, h(InstallPanel, { inst: inst, inputValues: inputValues, setInputValues: setInputValues, submit: submit, cancel: cancelInstall })) : null,
         activeTab === "plugins" ? h(PluginTab, tabProps) : h(SkillsTab, tabProps),

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,20 +40,6 @@ window.__ModuleLoader__.load({
       dataSourceSearch: "⚠ 网络索引源不可用，当前为搜索兜底结果（不完整）",
       dataSourceBundled: "当前显示插件内置索引（离线可用；点「刷新」获取最新）",
       dedupeHint: "{n} 个同名包已隐藏（同名 npm 包只能安装一个）",
-      backupTitle: "备份与恢复",
-      backupExport: "导出备份",
-      backupImport: "导入并恢复",
-      backupWebdavUrl: "WebDAV 地址",
-      backupWebdavUser: "用户名",
-      backupWebdavPass: "密码",
-      backupWebdavPush: "备份到 WebDAV",
-      backupWebdavPull: "从 WebDAV 恢复",
-      backupDownloadOk: "备份已导出（JSON 文件）",
-      backupRestoreStart: "开始恢复 {n} 个插件（逐个走安装流程）…",
-      backupRestoreDone: "备份恢复完成 ✔",
-      backupRestoreErr: "恢复失败: {err}",
-      backupBadFile: "备份文件格式不正确",
-      backupNote: "备份含安装记录（仓库/类型/版本），不含密钥（环境变量从不持久化）",
       updatedAt: "更新于 {d}",
       githubLink: "Github原链",
       tags: "标签: {tags}",
@@ -135,20 +121,6 @@ window.__ModuleLoader__.load({
       dataSourceSearch: "⚠ index sources unreachable — showing partial search results",
       dataSourceBundled: "Showing the bundled index (offline-ready; click Refresh for the latest)",
       dedupeHint: "{n} duplicate packages hidden (same npm package can only be installed once)",
-      backupTitle: "Backup & Restore",
-      backupExport: "Export backup",
-      backupImport: "Import & restore",
-      backupWebdavUrl: "WebDAV URL",
-      backupWebdavUser: "Username",
-      backupWebdavPass: "Password",
-      backupWebdavPush: "Backup to WebDAV",
-      backupWebdavPull: "Restore from WebDAV",
-      backupDownloadOk: "Backup exported (JSON file)",
-      backupRestoreStart: "Restoring {n} plugins (one by one through the install flow)…",
-      backupRestoreDone: "Backup restore complete ✔",
-      backupRestoreErr: "Restore failed: {err}",
-      backupBadFile: "Invalid backup file",
-      backupNote: "Backup holds install records (repo/type/version); secrets are never persisted, so nothing sensitive is included",
       updatedAt: "updated {d}",
       githubLink: "GitHub repo",
       tags: "Tags: {tags}",
@@ -412,8 +384,9 @@ window.__ModuleLoader__.load({
       );
     }
 
-    /** DSH 插件 tab：现有市场列表逻辑 + 分类筛选。 */
+    /** DSH 插件 tab：现有市场列表逻辑 + 分类筛选 + 分页懒加载。 */
     var CATEGORY_KEYS = ["vision", "document", "memory", "model", "notify", "coding", "conversation", "web-ui", "agent", "tool", "resource", "other"];
+    var PLUGIN_PAGE_SIZE = 60;
     function PluginTab(props) {
       var state = useState(null); var repos = state[0]; var setRepos = state[1];
       var state2 = useState(null); var error = state2[0]; var setError = state2[1];
@@ -421,12 +394,13 @@ window.__ModuleLoader__.load({
       var state4 = useState("all"); var category = state4[0]; var setCategory = state4[1];
       var state5 = useState(""); var dataSource = state5[0]; var setDataSource = state5[1];
       var state6 = useState(0); var dropped = state6[0]; var setDropped = state6[1];
+      var state7 = useState(PLUGIN_PAGE_SIZE); var visible = state7[0]; var setVisible = state7[1];
 
       function doRefresh(force) {
         props.showToast(t("refreshing"), true);
         fetch("/api/marketplace/list?lang=" + langCurrent + (force ? "&refresh=1" : ""), { headers: { "X-DSH-Marketplace": "1" } }).then(function (r) { return r.json(); }).then(function (data) {
           if (data.error) { setError(data.error); props.showToast(t("refreshFail", { err: data.error }), false); }
-          else { setRepos(data.repos || []); setDataSource(data.source || ""); setDropped(data.dropped || 0); props.showToast(t("refreshOk", { n: (data.repos || []).length }), true); }
+          else { setRepos(data.repos || []); setVisible(PLUGIN_PAGE_SIZE); setDataSource(data.source || ""); setDropped(data.dropped || 0); props.showToast(t("refreshOk", { n: (data.repos || []).length }), true); }
         }).catch(function (err) {
           props.showToast(t("refreshFail", { err: String(err) }), false);
         });
@@ -438,10 +412,26 @@ window.__ModuleLoader__.load({
         fetch("/api/marketplace/list?lang=" + langCurrent, { headers: { "X-DSH-Marketplace": "1" } }).then(function (r) { return r.json(); }).then(function (data) {
           if (cancelled) return;
           if (data.error) { setError(data.error); setRepos([]); }
-          else { setRepos(data.repos || []); setDataSource(data.source || ""); setDropped(data.dropped || 0); }
+          else { setRepos(data.repos || []); setVisible(PLUGIN_PAGE_SIZE); setDataSource(data.source || ""); setDropped(data.dropped || 0); }
         }).catch(function (err) { if (!cancelled) { setError(String(err)); setRepos([]); } });
         return function () { cancelled = true; };
       }, [props.tick]);
+
+      // 搜索词/分类变化时重置分页（搜索在完整数组 filter 后重新分页）
+      useEffect(function () { setVisible(PLUGIN_PAGE_SIZE); }, [query, category]);
+
+      // 触底加载：sentinel 进入视口 → 追加一页（与 Skills tab 相同的交互）
+      useEffect(function () {
+        var el = document.getElementById("dshm-plugins-sentinel");
+        if (!el) return;
+        var observer = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) setVisible(function (n) { return n + PLUGIN_PAGE_SIZE; });
+          });
+        }, { rootMargin: "300px" });
+        observer.observe(el);
+        return function () { observer.disconnect(); };
+      }, [repos, query, category]);
 
       return h("div", null,
         h("div", { style: s.head },
@@ -483,14 +473,17 @@ window.__ModuleLoader__.load({
             if (!q) return true;
             return (r.name + " " + r.full_name + " " + (r.topics || []).join(" ")).toLowerCase().indexOf(q) !== -1;
           });
+          var shown = list.slice(0, visible);
+          var hasMore = shown.length < list.length;
           return [
             h("p", { key: "count", style: Object.assign({}, s.meta, { margin: "0 0 8px" }) },
               t("countTotal", { n: repos.length }) + ((q || category !== "all") ? t("countMatch", { n: list.length }) : "")),
             dropped > 0 ? h("p", { key: "dedupe", style: s.srcHint }, t("dedupeHint", { n: dropped })) : null,
-            list.map(function (repo) {
+            shown.map(function (repo) {
               // 全局互斥：任何安装进行中 → 所有按钮禁用；只有正在安装的那个显示「安装中...」
               return h(RepoCard, { key: repo.full_name, repo: repo, installed: repo.installed, updateAvailable: repo.updateAvailable, busy: !!(props.inst && props.inst.phase === "running"), selfBusy: !!(props.inst && props.inst.phase === "running" && props.inst.repo === repo.full_name), uninstalling: props.uninstalling, onUninstall: props.onUninstall, onInstall: function (fullName) { props.setInputValues({}); props.runInstall(fullName, {}, []); } });
             }),
+            hasMore ? h("div", { key: "sentinel", id: "dshm-plugins-sentinel", style: { height: 1 } }) : null,
             list.length === 0 ? h("p", { key: "empty", style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, q ? t("noMatch", { q: query }) : t("noMatchCat")) : null
           ];
         })() : null,
@@ -498,73 +491,61 @@ window.__ModuleLoader__.load({
       );
     }
 
-    /** 通用 Skills tab：服务端分页（每页 100，#14），搜索下推服务端，触底加载下一页。 */
-    var SKILL_PAGE_SIZE = 100;
-    var skillsFetchSeq = 0; // 模块级请求序号：查询/刷新/翻页竞态时丢弃过期响应
-    /** 备份恢复队列（模块级，单市场实例）：逐项走正常安装流程，awaiting-input 弹窗期间自动暂停。 */
-    var restoreState = { list: null, idx: 0 };
+    /** 通用 Skills tab：全量索引 + 分页（每页 60，IntersectionObserver 触底加载）。 */
+    var SKILL_PAGE_SIZE = 60;
     function SkillsTab(props) {
       var state = useState(null); var repos = state[0]; var setRepos = state[1];
       var state2 = useState(null); var error = state2[0]; var setError = state2[1];
       var state3 = useState(""); var query = state3[0]; var setQuery = state3[1];
-      var state4 = useState(1); var page = state4[0]; var setPage = state4[1];
+      var state4 = useState(SKILL_PAGE_SIZE); var visible = state4[0]; var setVisible = state4[1];
       var state5 = useState(""); var dataSource = state5[0]; var setDataSource = state5[1];
       var state6 = useState(0); var dropped = state6[0]; var setDropped = state6[1];
-      var state7 = useState(0); var total = state7[0]; var setTotal = state7[1];
-      var state8 = useState(false); var loading = state8[0]; var setLoading = state8[1];
-
-      function fetchPage(pg, q, refresh) {
-        var mySeq = ++skillsFetchSeq;
-        setLoading(true);
-        fetch("/api/marketplace/skills?lang=" + langCurrent + "&page=" + pg + "&pageSize=" + SKILL_PAGE_SIZE + "&q=" + encodeURIComponent(q || "") + (refresh ? "&refresh=1" : ""), { headers: { "X-DSH-Marketplace": "1" } })
-          .then(function (r) { return r.json(); })
-          .then(function (data) {
-            if (mySeq !== skillsFetchSeq) return; // 已被更新的请求取代
-            if (data.error) { setError(data.error); setLoading(false); }
-            else {
-              setRepos(function (prev) {
-                if (pg === 1) return data.repos || [];
-                var seen = {};
-                (prev || []).forEach(function (r) { seen[r.full_name] = true; });
-                return (prev || []).concat((data.repos || []).filter(function (r) { if (seen[r.full_name]) return false; seen[r.full_name] = true; return true; }));
-              });
-              setPage(pg);
-              setTotal(data.total != null ? data.total : (data.repos || []).length);
-              setDataSource(data.source || "");
-              setDropped(data.dropped || 0);
-              setError(null);
-              setLoading(false);
-            }
-          })
-          .catch(function (err) { if (mySeq === skillsFetchSeq) { setError(String(err)); setLoading(false); } });
-      }
 
       function doRefresh(force) {
         props.showToast(t("refreshing"), true);
-        fetchPage(1, query, true);
+        fetch("/api/marketplace/skills?lang=" + langCurrent + (force ? "&refresh=1" : ""), { headers: { "X-DSH-Marketplace": "1" } }).then(function (r) { return r.json(); }).then(function (data) {
+          if (data.error) { setError(data.error); props.showToast(t("refreshFail", { err: data.error }), false); }
+          else { setRepos(data.repos || []); setVisible(SKILL_PAGE_SIZE); setDataSource(data.source || ""); setDropped(data.dropped || 0); props.showToast(t("refreshOk", { n: (data.repos || []).length }), true); }
+        }).catch(function (err) {
+          props.showToast(t("refreshFail", { err: String(err) }), false);
+        });
       }
 
-      // 初始加载 / 外部 tick（安装卸载后刷新第一页）
-      useEffect(function () { fetchPage(1, "", false); }, [props.tick]);
-      // 搜索词变化 → 重置并加载第 1 页（搜索已下推服务端）
-      useEffect(function () { fetchPage(1, query, false); }, [query]);
+      useEffect(function () {
+        var cancelled = false;
+        setError(null);
+        fetch("/api/marketplace/skills?lang=" + langCurrent, { headers: { "X-DSH-Marketplace": "1" } }).then(function (r) { return r.json(); }).then(function (data) {
+          if (cancelled) return;
+          if (data.error) { setError(data.error); setRepos([]); }
+          else { setRepos(data.repos || []); setVisible(SKILL_PAGE_SIZE); setDataSource(data.source || ""); setDropped(data.dropped || 0); }
+        }).catch(function (err) { if (!cancelled) { setError(String(err)); setRepos([]); } });
+        return function () { cancelled = true; };
+      }, [props.tick]);
 
-      // 触底加载：sentinel 进入视口且未加载完 → 下一页
+      // 搜索词变化时重置分页（搜索在完整数组 filter 后重新分页）
+      useEffect(function () { setVisible(SKILL_PAGE_SIZE); }, [query]);
+
+      // 触底加载：sentinel 进入视口 → 追加一页
       useEffect(function () {
         var el = document.getElementById("dshm-skills-sentinel");
         if (!el) return;
         var observer = new IntersectionObserver(function (entries) {
           entries.forEach(function (entry) {
-            if (entry.isIntersecting && !loading && repos && repos.length < total) {
-              fetchPage(page + 1, query, false);
-            }
+            if (entry.isIntersecting) setVisible(function (n) { return n + SKILL_PAGE_SIZE; });
           });
         }, { rootMargin: "300px" });
         observer.observe(el);
         return function () { observer.disconnect(); };
-      }, [repos, query, total, loading]);
+      }, [repos, query]);
 
       var q = query.trim().toLowerCase();
+      var list = q
+        ? (repos || []).filter(function (r) {
+            return (r.name + " " + r.full_name + " " + (r.topics || []).join(" ")).toLowerCase().indexOf(q) !== -1;
+          })
+        : (repos || []);
+      var shown = list.slice(0, visible);
+      var hasMore = shown.length < list.length;
 
       return h("div", null,
         h("div", { style: s.head },
@@ -589,15 +570,15 @@ window.__ModuleLoader__.load({
         repos === null ? h("p", { style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("loading")) : null,
         repos ? [
           h("p", { key: "count", style: Object.assign({}, s.meta, { margin: "0 0 8px" }) },
-            t("countSkills", { n: total }) + (q ? t("countMatch", { n: total }) : "")),
+            t("countSkills", { n: repos.length }) + (q ? t("countMatch", { n: list.length }) : "")),
           dropped > 0 ? h("p", { key: "dedupe", style: s.srcHint }, t("dedupeHint", { n: dropped })) : null,
-          repos.map(function (repo) {
+          shown.map(function (repo) {
             return h(RepoCard, { key: repo.full_name, repo: repo, installed: repo.installed, updateAvailable: false, busy: !!(props.inst && props.inst.phase === "running"), selfBusy: !!(props.inst && props.inst.phase === "running" && props.inst.repo === repo.full_name), uninstalling: props.uninstalling, onUninstall: props.onUninstall, onInstall: function (fullName) { props.setInputValues({}); props.runInstall(fullName, {}, []); } });
           }),
-          repos.length < total && !loading ? h("div", { key: "sentinel", id: "dshm-skills-sentinel", style: { height: 1 } }) : null,
-          repos.length === 0 && !loading ? h("p", { key: "empty", style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("noMatch", { q: query })) : null
+          hasMore ? h("div", { key: "sentinel", id: "dshm-skills-sentinel", style: { height: 1 } }) : null,
+          list.length === 0 ? h("p", { key: "empty", style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("noMatch", { q: query })) : null
         ] : null,
-        repos && repos.length === 0 && !error && !loading ? h("p", { style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("skillsEmpty")) : null
+        repos && repos.length === 0 && !error ? h("p", { style: { fontSize: 13, color: "var(--dsw-alias-label-tertiary)" } }, t("skillsEmpty")) : null
       );
     }
 
@@ -663,21 +644,12 @@ window.__ModuleLoader__.load({
           // 安装结束（非等待输入）：两个 tab 都重新拉取列表——服务端实时标注 installed，
           // 安装成功的卡片自动变「已安装」并置顶，无需本地拼装状态
           if (data.status !== "awaiting-input") setTick(tick + 1);
-          // 备份恢复队列推进（manual/aborted 也继续下一个，避免卡死）
-          if (data.status !== "awaiting-input" && restoreState.list) {
-            restoreState.idx++;
-            nextRestore();
-          }
         }).catch(function (err) {
           setInst(function (prev) {
             if (!prev || prev.repo !== repo) return prev;
             return { repo: repo, phase: "failed", log: (prev.log || []).concat([t("requestFail", { err: String(err) })]), questions: [], answers: answers || {}, result: null };
           });
           setTick(tick + 1);
-          if (restoreState.list) {
-            restoreState.idx++;
-            nextRestore();
-          }
         });
       }
 
@@ -730,94 +702,6 @@ window.__ModuleLoader__.load({
         setToast({ text: text, ok: !!ok });
       }
 
-      // ---- 备份 / 恢复（#15）----
-      var wdState1 = useState(""); var wdUrl = wdState1[0]; var setWdUrl = wdState1[1];
-      var wdState2 = useState(""); var wdUser = wdState2[0]; var setWdUser = wdState2[1];
-      var wdState3 = useState(""); var wdPass = wdState3[0]; var setWdPass = wdState3[1];
-
-      function nextRestore() {
-        if (!restoreState.list) return;
-        if (restoreState.idx >= restoreState.list.length) {
-          restoreState.list = null;
-          showToast(t("backupRestoreDone"), true);
-          setTick(tick + 1);
-          return;
-        }
-        runInstall(restoreState.list[restoreState.idx], {}, []);
-      }
-
-      function startRestore(repoList) {
-        if (restoreState.list) return; // 已在恢复中
-        if (!Array.isArray(repoList) || repoList.length === 0) return;
-        restoreState.list = repoList;
-        restoreState.idx = 0;
-        showToast(t("backupRestoreStart", { n: repoList.length }), true);
-        nextRestore();
-      }
-
-      function exportBackup() {
-        fetch("/api/marketplace/backup", { headers: { "X-DSH-Marketplace": "1" } })
-          .then(function (r) { return r.json(); })
-          .then(function (data) {
-            if (data.error || !data.backup) { showToast(data.error || t("backupRestoreErr", { err: "empty" }), false); return; }
-            var blob = new Blob([JSON.stringify(data.backup, null, 2)], { type: "application/json" });
-            var a = document.createElement("a");
-            a.href = URL.createObjectURL(blob);
-            a.download = "dsh-marketplace-backup-" + new Date().toISOString().slice(0, 10) + ".json";
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            URL.revokeObjectURL(a.href);
-            showToast(t("backupDownloadOk"), true);
-          })
-          .catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
-      }
-
-      function importBackupFile(file) {
-        if (!file || restoreState.list) return;
-        var reader = new FileReader();
-        reader.onload = function () {
-          var backup;
-          try { backup = JSON.parse(String(reader.result)); } catch (e) { showToast(t("backupBadFile"), false); return; }
-          fetch("/api/marketplace/restore/diff", {
-            method: "POST",
-            headers: { "Content-Type": "application/json", "X-DSH-Marketplace": "1" },
-            body: JSON.stringify({ backup: backup })
-          }).then(function (r) { return r.json(); }).then(function (data) {
-            if (data.error) { showToast(data.error, false); return; }
-            showToast((data.log || []).join(" ") || t("backupRestoreDone"), true);
-            if (Array.isArray(data.missing) && data.missing.length > 0) startRestore(data.missing);
-          }).catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
-        };
-        reader.readAsText(file);
-      }
-
-      function webdavPush() {
-        if (restoreState.list) return;
-        fetch("/api/marketplace/backup/webdav", {
-          method: "POST",
-          headers: { "Content-Type": "application/json", "X-DSH-Marketplace": "1" },
-          body: JSON.stringify({ url: wdUrl.trim(), username: wdUser.trim(), password: wdPass })
-        }).then(function (r) { return r.json(); }).then(function (data) {
-          showToast((data.log || []).join(" ") || (data.error || t("backupRestoreErr", { err: "webdav" })), data.status === "done");
-        }).catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
-      }
-
-      function webdavPull() {
-        if (restoreState.list) return;
-        fetch("/api/marketplace/restore/webdav", {
-          method: "POST",
-          headers: { "Content-Type": "application/json", "X-DSH-Marketplace": "1" },
-          body: JSON.stringify({ url: wdUrl.trim(), username: wdUser.trim(), password: wdPass })
-        }).then(function (r) { return r.json(); }).then(function (data) {
-          if (data.error) { showToast(data.error, false); return; }
-          showToast((data.log || []).join(" ") || t("backupRestoreDone"), true);
-          if (Array.isArray(data.missing) && data.missing.length > 0) startRestore(data.missing);
-        }).catch(function (err) { showToast(t("backupRestoreErr", { err: String(err) }), false); });
-      }
-
-      var wdInputStyle = Object.assign({}, s.input, { width: 150, marginTop: 0 });
-
       var tabProps = { inst: inst, runInstall: runInstall, setInputValues: setInputValues, tick: tick, showToast: showToast, uninstalling: uninstallingRepo, onUninstall: uninstallPlugin };
 
       return h("div", { style: s.page },
@@ -826,20 +710,6 @@ window.__ModuleLoader__.load({
         h("div", { style: s.tabBar },
           h("button", { style: activeTab === "plugins" ? s.tabActive : s.tabBtn, onClick: function () { setActiveTab("plugins"); } }, t("tabPlugins")),
           h("button", { style: activeTab === "skills" ? s.tabActive : s.tabBtn, onClick: function () { setActiveTab("skills"); } }, t("tabSkills"))
-        ),
-        h("div", { key: "backup", style: { border: "1px solid var(--dsw-alias-border-l2)", borderRadius: 10, padding: "10px 14px", margin: "0 0 12px" } },
-          h("p", { style: { fontSize: 12, fontWeight: 600, margin: "0 0 8px", color: "var(--dsw-alias-label-secondary)" } }, t("backupTitle")),
-          h("div", { style: { display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" } },
-            h("button", { className: "dshm-btn", style: s.btn, onClick: exportBackup }, t("backupExport")),
-            h("button", { className: "dshm-btn", style: s.btn, onClick: function () { var el = document.getElementById("dshm-backup-file"); if (el) el.click(); } }, t("backupImport")),
-            h("input", { id: "dshm-backup-file", type: "file", accept: ".json,application/json", style: { display: "none" }, onChange: function (e) { importBackupFile(e.target.files && e.target.files[0]); e.target.value = ""; } }),
-            h("input", { style: wdInputStyle, placeholder: t("backupWebdavUrl"), value: wdUrl, onChange: function (e) { setWdUrl(e.target.value); } }),
-            h("input", { style: Object.assign({}, wdInputStyle, { width: 100 }), placeholder: t("backupWebdavUser"), value: wdUser, onChange: function (e) { setWdUser(e.target.value); } }),
-            h("input", { style: Object.assign({}, wdInputStyle, { width: 100 }), type: "password", placeholder: t("backupWebdavPass"), value: wdPass, onChange: function (e) { setWdPass(e.target.value); } }),
-            h("button", { className: "dshm-btn", style: s.btn, onClick: webdavPush }, t("backupWebdavPush")),
-            h("button", { className: "dshm-btn", style: s.btn, onClick: webdavPull }, t("backupWebdavPull"))
-          ),
-          h("p", { style: { fontSize: 11, color: "var(--dsw-alias-label-tertiary)", margin: "6px 0 0" } }, t("backupNote"))
         ),
         inst ? h("div", { style: s.installOverlay }, h(InstallPanel, { inst: inst, inputValues: inputValues, setInputValues: setInputValues, submit: submit, cancel: cancelInstall })) : null,
         activeTab === "plugins" ? h(PluginTab, tabProps) : h(SkillsTab, tabProps),


### PR DESCRIPTION
## 问题

插件列表当前一次性渲染全部卡片（1000+ DOM 节点），进入市场页面时可能出现明显卡顿。

## 修复

- `lib/client.js`：插件列表复用 Skills 页已有的分页懒加载模式
  - 首屏只渲染 60 张卡片
  - 底部 sentinel + IntersectionObserver，触底追加下一页
  - 搜索 / 分类切换时重置分页
- 版本检测、更新按钮、排序、搜索均在完整数据上完成，分页只作用于最终渲染，不影响已有功能

## 验证

- `node --check lib/client.js` 通过
- 手动验证：进入市场首屏只渲染 60 张卡片，滚动到底自动加载，切换搜索词/分类后从第一页开始