### PR TITLE
fix(install): 安装/卸载正确性系列（幂等注册/精确相等/缓存卫生）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -88,7 +88,7 @@ The plugin lives at `~/.dsh/profiles/web/node_modules/dsh-plugin-marketplace/` a
 
 ```yaml
 - insert:
-    - id: plugin-marketplace
+    - id: dsh-plugin-marketplace
       name: dsh-plugin-marketplace
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ dsh plugin --profile web install bradeGithub/DSH-Plugins-Marketplace   # 重装�
 
 ```yaml
 - insert:
-    - id: plugin-marketplace
+    - id: dsh-plugin-marketplace
       name: dsh-plugin-marketplace
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -52,9 +52,6 @@ Remove-Item (Join-Path $dest "install.ps1") -Force -ErrorAction SilentlyContinue
 Remove-Item (Join-Path $dest "install.sh") -Force -ErrorAction SilentlyContinue
 Remove-Item (Join-Path $dest ".ca-bundle.crt") -Force -ErrorAction SilentlyContinue
 
-# 注册到 web profile 补丁（幂等；行级精确匹配，避免前缀子串误判）。
-# 注意：patch 条目是 `- insert:` 块内的缩进行（`      name: ...`），
-# 行首锚定必须允许前导空白，否则永远匹配不到 → 每次运行都会追加重复条目（KIMI 审阅 H1）。
 $patch = Join-Path $env:USERPROFILE ".dsh\profiles\web\cordis.patch.yml"
 $registered = $false
 if (Test-Path $patch) {

--- a/install.sh
+++ b/install.sh
@@ -56,9 +56,6 @@ cp -r "$SRC" "$DEST"
 rm -rf "$DEST/.git"
 rm -f "$DEST/install.ps1" "$DEST/install.sh" "$DEST/.ca-bundle.crt"
 
-# 注册到 web profile 补丁（幂等；行级精确匹配，避免前缀子串误判）。
-# 注意：patch 条目是 `- insert:` 块内的缩进行（`      name: ...`），
-# 行首锚定必须允许前导空白，否则永远匹配不到 → 每次运行都会追加重复条目（KIMI 审阅 H1）。
 PATCH="$HOME/.dsh/profiles/web/cordis.patch.yml"
 if [[ -f "$PATCH" ]] && grep -qE '^[[:space:]]*name:[[:space:]]+dsh-plugin-marketplace[[:space:]]*$' "$PATCH"; then
   echo "Already registered in cordis.patch.yml (skipped)"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1068,8 +1068,12 @@ async function removePatchEntry(pkgName) {
     }
     flushBlock();
     let next = out.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n+$/, "\n");
-    // 条目删空后回落为合法空文档，避免 loader 解析失败
-    if (!/^- insert:/m.test(next)) next = "[]\n";
+    // 条目删空后回落为合法空文档，避免 loader 解析失败。
+    // 仅当无任何实质内容（空行/注释除外）时才重置——若还有非 insert 顶层内容
+    // （如 dsh-skin managed 块），必须保留，绝不能整文件清空（卸载最后一个插件
+    // 会清掉 DSH 皮肤配置，实测暴露）。
+    const hasContent = out.some((l) => l.trim() !== "" && !l.trim().startsWith("#"));
+    if (!hasContent) next = "[]\n";
     const tmp = PATCH_FILE + ".tmp";
     await writeFile(tmp, next, "utf8");
     await rename(tmp, PATCH_FILE);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1326,21 +1326,43 @@ function dedupeReposByPkgName(repos, isInstalled = (r) => hasInstalledRecord(r.f
   return { repos: [...byKey.values()], dropped };
 }
 
-/** 读磁盘缓存（上次成功拉取的完整索引）；无缓存/损坏返回 null。 */
+/**
+ * 读磁盘缓存（上次成功拉取的完整索引）；无缓存/损坏/缺 generated_at/过期/坏条目返回 null。
+ * 与 writeListCache 配套（L1 修复）：search 兜底不再落盘后，磁盘缓存只可能是
+ * registry 成功时写入的完整索引（带 generated_at）——逐项校验才能保证
+ * registry 全挂时兜底用的缓存是新鲜且结构完整的。
+ */
 async function readListCache(kind) {
   try {
     const data = JSON.parse(await readFile(listCacheFile(kind), "utf8"));
-    if (Array.isArray(data.repos) && data.repos.length > 0) return data.repos;
+    if (data && typeof data === "object" && Array.isArray(data.repos) && data.repos.length > 0) {
+      // 新鲜度校验：generated_at 缺失（旧格式/被篡改）或超过 REGISTRY_MAX_AGE_MS 视为无效，
+      // 返回 null 走下一级数据源——过期的旧索引不再被长期兜底使用。
+      const age = Date.now() - Date.parse(data.generated_at ?? "");
+      if (Number.isNaN(age) || age > REGISTRY_MAX_AGE_MS) return null;
+      // 条目基础校验：full_name 非字符串的坏条目丢弃（文件被篡改/半写时的残渣）。
+      // 缓存里的是 registry 成功写入的已归一化条目，直接采用。
+      const valid = [];
+      for (const r of data.repos) {
+        if (r && typeof r === "object" && typeof r.full_name === "string" && r.full_name.length > 0) valid.push(r);
+      }
+      if (valid.length > 0) return valid;
+    }
   } catch { /* 无缓存或损坏 */ }
   return null;
 }
 
-/** 写磁盘缓存。只在完整索引（registry / bundled）成功时调用——搜索兜底结果天然
- *  残缺（Search API 单 query 上限 1000 条），落盘会把好缓存降级成残缺索引（#12）。 */
+/**
+ * 写磁盘缓存。只在完整索引（registry / bundled）成功时调用——搜索兜底结果天然
+ * 残缺（Search API 单 query 上限 1000 条），落盘会把好缓存降级成残缺索引（#12）。
+ * generated_at 记写入时刻（紧跟 registry 成功拉取，与索引拉取时刻同一量级），
+ * readListCache 按 REGISTRY_MAX_AGE_MS 校验其新鲜度。
+ */
 async function writeListCache(kind, repos) {
   try {
     await mkdir(LIST_CACHE_DIR, { recursive: true });
-    await writeFile(listCacheFile(kind), JSON.stringify({ saved_at: new Date().toISOString(), kind, count: repos.length, repos }, null, 2), "utf8");
+    const generatedAt = new Date().toISOString();
+    await writeFile(listCacheFile(kind), JSON.stringify({ saved_at: generatedAt, generated_at: generatedAt, kind, count: repos.length, repos }, null, 2), "utf8");
   } catch { /* 缓存写失败不阻断主流程 */ }
 }
 
@@ -1404,6 +1426,9 @@ async function fetchAllRepos(kind = "dsh", force = false) {
   }
   // #12：搜索兜底结果不写磁盘缓存——残缺结果会把上次成功的完整索引降级。
   const fromSearch = await fetchSearchRepos(kind);
+  // search 兜底不写盘（L1 修复）：Search API 单 query 上限 1000 条（skills 兜底仅 266），
+  // 残缺结果只作当次响应，绝不落盘——否则 registry 全挂时磁盘缓存长期提供残缺数据。
+  // 磁盘缓存从此只在 registry 成功时写入（带 generated_at，见 writeListCache）。
   listSources[kind] = "search";
   fromSearch.sort((a, b) => (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0));
   return fromSearch;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2948,9 +2948,15 @@ function apply(ctx) {
                 }
               }
             } else {
+              // L1 修复：多 skill / 多预设仓库安装时 location 记为 SKILLS_DIR / PRESETS_DIR 本身
+              //（无尾分隔符，见 installRepo 多根分支）——此前仅前缀校验恒 false，rm 被跳过、
+              // 目录残留而记录已删；精确相等（=== 目录本身）同样放行，仍受受管目录约束，无越界。
               const location = String(record.location ?? "");
-              const insideManaged = resolve(location).startsWith(resolve(SKILLS_DIR) + sep)
-                || resolve(location).startsWith(resolve(PRESETS_DIR) + sep);
+              const skillsDir = resolve(SKILLS_DIR);
+              const presetsDir = resolve(PRESETS_DIR);
+              const loc = resolve(location);
+              const insideManaged = loc === skillsDir || loc === presetsDir
+                || loc.startsWith(skillsDir + sep) || loc.startsWith(presetsDir + sep);
               if (location && insideManaged) {
                 await rm(location, { recursive: true, force: true }).catch(() => {});
                 removed++;

--- a/scripts/tests/e2e/install.e2e.mjs
+++ b/scripts/tests/e2e/install.e2e.mjs
@@ -217,7 +217,7 @@ function setupUrlRewrite(owner, repoName) {
   // 2) 内置索引缺失（临时移开）→ 磁盘缓存兜底
   renameSync(bundledDsh, bundledDsh + ".bak");
   try {
-    writeFileSync(join(cacheDir2, "dsh.json"), JSON.stringify({ saved_at: new Date().toISOString(), kind: "dsh", count: 1, repos: [cachedRepo] }), "utf8");
+    writeFileSync(join(cacheDir2, "dsh.json"), JSON.stringify({ saved_at: new Date().toISOString(), generated_at: new Date().toISOString(), kind: "dsh", count: 1, repos: [cachedRepo] }), "utf8");
     const cachedList = await lib.fetchAllRepos("dsh");
     check("e2e 磁盘缓存兜底返回缓存条目", cachedList.some((r) => r.full_name === "cached-owner/demo-cached"), true);
 
@@ -239,7 +239,7 @@ function setupUrlRewrite(owner, repoName) {
   // 5) skills 内置缺失（临时移开）→ 磁盘缓存兜底
   renameSync(bundledSkills, bundledSkills + ".bak");
   try {
-    writeFileSync(join(cacheDir2, "skills.json"), JSON.stringify({ saved_at: new Date().toISOString(), kind: "skills", count: 2, repos: [cachedRepo, { ...cachedRepo, full_name: "cached-owner/demo-cached-2", name: "demo-cached-2" }] }), "utf8");
+    writeFileSync(join(cacheDir2, "skills.json"), JSON.stringify({ saved_at: new Date().toISOString(), generated_at: new Date().toISOString(), kind: "skills", count: 2, repos: [cachedRepo, { ...cachedRepo, full_name: "cached-owner/demo-cached-2", name: "demo-cached-2" }] }), "utf8");
     const cachedSkills = await lib.fetchAllRepos("skills");
     check("e2e skills 磁盘缓存兜底 2 条", cachedSkills.length, 2);
   } finally {

--- a/scripts/tests/integration/install-scripts.test.mjs
+++ b/scripts/tests/integration/install-scripts.test.mjs
@@ -1,0 +1,110 @@
+// install.sh / install.ps1 沙箱行为测试——临时 HOME/USERPROFILE 跑真实脚本，验证幂等契约。
+//
+// 场景（契约 = README 与实际环境 cordis.patch.yml 行为一致）：
+//   A 全新环境：注册一次，追加条目 id=dsh-plugin-marketplace
+//   B 已含真实嵌套条目（`- insert:` 块内缩进 name 行）：跳过，不追加
+//   D 全新环境连跑 3 次：只注册一次（幂等）
+//
+// 依赖：install.sh 用 bash（Git Bash / CI Linux 均可用）；
+//       install.ps1 用 pwsh（Windows 本机执行，其他平台跳过）。
+// 契约的静态断言见 unit/install-scripts.test.mjs（跨平台必跑）。
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+}
+
+const INDENTED_ENTRY = `# 注释\n- insert:\n    - id: dsh-plugin-marketplace\n      name: dsh-plugin-marketplace\n`;
+
+function patchPath(home) {
+  return join(home, ".dsh", "profiles", "web", "cordis.patch.yml");
+}
+function readPatch(home) {
+  const p = patchPath(home);
+  return existsSync(p) ? readFileSync(p, "utf8") : "";
+}
+
+// ---- install.sh：bash 沙箱（场景 A/B/D）----
+function runSh(home) {
+  execFileSync("bash", [join(ROOT, "install.sh")], {
+    env: { ...process.env, HOME: home },
+    cwd: ROOT,
+    stdio: "pipe"
+  });
+}
+
+// A：全新环境
+const homeA = mkdtempSync(join(tmpdir(), "dsh-inst-sh-a-"));
+try {
+  runSh(homeA);
+  const patch = readPatch(homeA);
+  check("sh-A: 全新环境注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
+  check("sh-A: 追加 id 为 dsh-plugin-marketplace", /- id: dsh-plugin-marketplace/.test(patch), true);
+  check("sh-A: 非独立 plugin-marketplace id", !/- id: plugin-marketplace(?![-\w])/.test(patch), true);
+} finally { rmSync(homeA, { recursive: true, force: true }); }
+
+// B：已含真实嵌套条目（缩进 name 行）→ 跳过
+const homeB = mkdtempSync(join(tmpdir(), "dsh-inst-sh-b-"));
+try {
+  mkdirSync(join(homeB, ".dsh", "profiles", "web"), { recursive: true });
+  writeFileSync(patchPath(homeB), INDENTED_ENTRY, "utf8");
+  runSh(homeB);
+  check("sh-B: 嵌套条目已注册 → 跳过不追加", readPatch(homeB), INDENTED_ENTRY);
+} finally { rmSync(homeB, { recursive: true, force: true }); }
+
+// D：全新环境连跑 3 次 → 只注册一次
+const homeD = mkdtempSync(join(tmpdir(), "dsh-inst-sh-d-"));
+try {
+  for (let i = 0; i < 3; i++) runSh(homeD);
+  const patch = readPatch(homeD);
+  check("sh-D: 连跑 3 次只注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
+} finally { rmSync(homeD, { recursive: true, force: true }); }
+
+// ---- install.ps1：pwsh 沙箱（仅 Windows 本机）----
+if (process.platform === "win32") {
+  function runPs1(userProfile) {
+    execFileSync("pwsh", ["-NoProfile", "-File", join(ROOT, "install.ps1")], {
+      env: { ...process.env, USERPROFILE: userProfile },
+      cwd: ROOT,
+      stdio: "pipe"
+    });
+  }
+  // A：全新环境
+  const psA = mkdtempSync(join(tmpdir(), "dsh-inst-ps-a-"));
+  try {
+    runPs1(psA);
+    const patch = readPatch(psA);
+    check("ps1-A: 全新环境注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
+    check("ps1-A: 追加 id 为 dsh-plugin-marketplace", /- id: dsh-plugin-marketplace/.test(patch), true);
+  } finally { rmSync(psA, { recursive: true, force: true }); }
+  // B：嵌套条目跳过
+  const psB = mkdtempSync(join(tmpdir(), "dsh-inst-ps-b-"));
+  try {
+    mkdirSync(join(psB, ".dsh", "profiles", "web"), { recursive: true });
+    writeFileSync(patchPath(psB), INDENTED_ENTRY, "utf8");
+    runPs1(psB);
+    check("ps1-B: 嵌套条目已注册 → 跳过不追加", readPatch(psB), INDENTED_ENTRY);
+  } finally { rmSync(psB, { recursive: true, force: true }); }
+  // D：连跑 3 次
+  const psD = mkdtempSync(join(tmpdir(), "dsh-inst-ps-d-"));
+  try {
+    for (let i = 0; i < 3; i++) runPs1(psD);
+    const patch = readPatch(psD);
+    check("ps1-D: 连跑 3 次只注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
+  } finally { rmSync(psD, { recursive: true, force: true }); }
+} else {
+  console.log("SKIP ps1 沙箱（非 Windows 平台，需 pwsh）");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/tests/integration/install-scripts.test.mjs
+++ b/scripts/tests/integration/install-scripts.test.mjs
@@ -10,7 +10,7 @@
 // 契约的静态断言见 unit/install-scripts.test.mjs（跨平台必跑）。
 
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -73,35 +73,67 @@ try {
 // ---- install.ps1：pwsh 沙箱（仅 Windows 本机）----
 if (process.platform === "win32") {
   function runPs1(userProfile) {
-    execFileSync("pwsh", ["-NoProfile", "-File", join(ROOT, "install.ps1")], {
-      env: { ...process.env, USERPROFILE: userProfile },
-      cwd: ROOT,
-      stdio: "pipe"
-    });
+    // 沙箱隔离：宿主 dsh CLI 会令脚本走「官方安装」分支（写真实 profile 而非
+    // USERPROFILE，且每次 60s+）——PATH 前置必然失败的 stub dsh：脚本
+    // $ErrorActionPreference=Stop 下外部命令非零退出即抛异常 → catch 回退手动分支，
+    // 沙箱断言才成立（install.ps1 顶部的 dsh 检测本意是真实用户环境的优化）。
+    // 不直接跑仓库根 install.ps1：$PSScriptRoot=仓库根 → Copy-Item 复制整个仓库
+    // （含 .git，~60MB 逐文件 + Defender 扫描 ~90s/次）——复制脚本到最小 fixture
+    // 目录（占位 package.json 满足 PSScriptRoot 检查），$src 只复制 KB 级内容。
+    const stubDir = mkdtempSync(join(tmpdir(), "dsh-stub-"));
+    const srcDir = mkdtempSync(join(tmpdir(), "dsh-ps1-src-"));
+    copyFileSync(join(ROOT, "install.ps1"), join(srcDir, "install.ps1"));
+    writeFileSync(join(srcDir, "package.json"), JSON.stringify({ name: "fixture-market", version: "1.0.0" }), "utf8");
+    writeFileSync(join(stubDir, "dsh.cmd"), "@echo off\r\nexit /b 1\r\n", "utf8");
+    writeFileSync(join(stubDir, "dsh"), "#!/bin/sh\nexit 1\n", "utf8");
+    const env = { ...process.env, USERPROFILE: userProfile, PATH: `${stubDir};${process.env.PATH ?? ""}` };
+    try {
+      // 超时兜底：网络/复制异常挂起时防止整个测试文件无限阻塞（超时抛 ETIMEDOUT 明确失败）
+      execFileSync("pwsh", ["-NoProfile", "-File", join(srcDir, "install.ps1")], {
+        env,
+        cwd: srcDir,
+        stdio: "pipe",
+        timeout: 100_000
+      });
+    } finally {
+      rmSync(stubDir, { recursive: true, force: true });
+      rmSync(srcDir, { recursive: true, force: true });
+    }
   }
-  // A：全新环境
+  // 并行化：install.ps1 每次真实下载仓库 zip（网络 IO，~6s/次），串行 5 次为
+  // integration 层主要耗时（~50s）。A/B/D 的 HOME 彼此独立，可并行执行；
+  // D 的 3 次连跑必须串行（同一 HOME 的幂等语义测试）。
   const psA = mkdtempSync(join(tmpdir(), "dsh-inst-ps-a-"));
-  try {
-    runPs1(psA);
-    const patch = readPatch(psA);
-    check("ps1-A: 全新环境注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
-    check("ps1-A: 追加 id 为 dsh-plugin-marketplace", /- id: dsh-plugin-marketplace/.test(patch), true);
-  } finally { rmSync(psA, { recursive: true, force: true }); }
-  // B：嵌套条目跳过
   const psB = mkdtempSync(join(tmpdir(), "dsh-inst-ps-b-"));
-  try {
-    mkdirSync(join(psB, ".dsh", "profiles", "web"), { recursive: true });
-    writeFileSync(patchPath(psB), INDENTED_ENTRY, "utf8");
-    runPs1(psB);
-    check("ps1-B: 嵌套条目已注册 → 跳过不追加", readPatch(psB), INDENTED_ENTRY);
-  } finally { rmSync(psB, { recursive: true, force: true }); }
-  // D：连跑 3 次
   const psD = mkdtempSync(join(tmpdir(), "dsh-inst-ps-d-"));
-  try {
-    for (let i = 0; i < 3; i++) runPs1(psD);
-    const patch = readPatch(psD);
-    check("ps1-D: 连跑 3 次只注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
-  } finally { rmSync(psD, { recursive: true, force: true }); }
+  await Promise.all([
+    (async () => {
+      // A：全新环境
+      try {
+        runPs1(psA);
+        const patch = readPatch(psA);
+        check("ps1-A: 全新环境注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
+        check("ps1-A: 追加 id 为 dsh-plugin-marketplace", /- id: dsh-plugin-marketplace/.test(patch), true);
+      } finally { rmSync(psA, { recursive: true, force: true }); }
+    })(),
+    (async () => {
+      // B：嵌套条目跳过
+      try {
+        mkdirSync(join(psB, ".dsh", "profiles", "web"), { recursive: true });
+        writeFileSync(patchPath(psB), INDENTED_ENTRY, "utf8");
+        runPs1(psB);
+        check("ps1-B: 嵌套条目已注册 → 跳过不追加", readPatch(psB), INDENTED_ENTRY);
+      } finally { rmSync(psB, { recursive: true, force: true }); }
+    })(),
+    (async () => {
+      // D：连跑 3 次（同一 HOME 串行）
+      try {
+        for (let i = 0; i < 3; i++) runPs1(psD);
+        const patch = readPatch(psD);
+        check("ps1-D: 连跑 3 次只注册一次", (patch.match(/name: dsh-plugin-marketplace/g) || []).length, 1);
+      } finally { rmSync(psD, { recursive: true, force: true }); }
+    })(),
+  ]);
 } else {
   console.log("SKIP ps1 沙箱（非 Windows 平台，需 pwsh）");
 }

--- a/scripts/tests/integration/list-cache.test.mjs
+++ b/scripts/tests/integration/list-cache.test.mjs
@@ -1,0 +1,168 @@
+// list 磁盘缓存（list-cache）修复测试（L1）：
+// 1. fetchAllRepos 全失败走 search 兜底时**不写盘**——残缺结果（单 query 上限 1000 条）
+//    只作当次响应，绝不落盘污染磁盘缓存；
+// 2. readListCache 读取时校验——generated_at 缺失（旧格式）/过期/坏条目 → 视为无效
+//    返回 null 走下一级（search）；有效缓存 → 正常返回且 full_name 非字符串的坏条目被丢弃。
+//
+// 独立文件的原因：lib 模块在 import 时按 DSH_HOME 计算模块级常量（LIST_CACHE_DIR 等），
+// 必须在本文件内先构造临时 DSH_HOME 再动态 import；且本文件独占控制 list-cache 目录
+// 状态（构造/清空/断言），避免与其他测试的缓存写入互相干扰。
+
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// 必须在 import lib 之前设置临时 DSH_HOME
+process.env.DSH_HOME = mkdtempSync(join(tmpdir(), "dsh-listcache-")).replace(/\\/g, "/");
+const home = process.env.DSH_HOME;
+const listCacheDir = join(home, "marketplace", "list-cache");
+const cacheFile = (kind) => join(listCacheDir, `${kind}.json`);
+const listCacheFiles = () => { try { return readdirSync(listCacheDir); } catch { return null; } }; // null = 目录不存在
+
+const lib = await import("../../../lib/index.js");
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++;
+  else {
+    fail++;
+    console.log(`FAIL ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+  }
+}
+
+// ---- mock：按 URL 分派——registry 源 vs 搜索 API；payload 传 null 表示该路失败（403）----
+function mockFetch(registryPayload, searchPayload) {
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes("/search/repositories")) {
+      if (searchPayload === null) return { ok: false, status: 403, json: async () => ({}), text: async () => "" };
+      return { ok: true, status: 200, json: async () => searchPayload, text: async () => "" };
+    }
+    if (registryPayload === null) return { ok: false, status: 403, json: async () => ({}), text: async () => "" };
+    return { ok: true, status: 200, json: async () => registryPayload, text: async () => "" };
+  };
+  return orig;
+}
+
+/** 轮询等待条件成立（registry 分支的写盘是 fire-and-forget，不 await，需轮询）。 */
+async function waitFor(predicate, timeoutMs = 3000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return predicate();
+}
+
+const searchItems = (fullNames) => ({
+  items: fullNames.map((fn) => ({ full_name: fn, name: fn.split("/")[1], stargazers_count: 1, updated_at: "2026-01-01T00:00:00Z", description: "x", html_url: `https://github.com/${fn}` })),
+  total_count: fullNames.length,
+});
+const cacheRepo = (full_name, over = {}) => ({
+  full_name, name: full_name.split("/")[1], description: "cached", html_url: `https://github.com/${full_name}`,
+  stargazers_count: 5, updated_at: "2026-01-01T00:00:00Z", default_branch: "main", topics: [],
+  license: null, pkg_name: null, version: null, category: null, has_skill: null, has_install_script: null, ...over,
+});
+const OLD = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString(); // 7 天前 → 过期
+
+// ==================== 修复 1：search 兜底不写盘 ====================
+
+// 场景 A：list-cache 目录不存在 → registry 全挂 + search 成功 → 返回 search 结果，且目录不被创建
+{
+  const orig = mockFetch(null, searchItems(["s1/skill-a"]));
+  const list = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("search 兜底返回当次结果", list.map((r) => r.full_name), ["s1/skill-a"]);
+  check("search 兜底不创建 list-cache 目录", listCacheFiles(), null);
+}
+
+// 场景 B：已有过期缓存文件 → search 兜底后文件不变（不覆盖、不新增）
+{
+  const staleContent = JSON.stringify({ saved_at: OLD, generated_at: OLD, kind: "dsh", count: 1, repos: [cacheRepo("c1/stale")] }, null, 2);
+  mkdirSync(listCacheDir, { recursive: true });
+  writeFileSync(cacheFile("dsh"), staleContent, "utf8");
+  const orig = mockFetch(null, searchItems(["s2/skill-b"]));
+  const list = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("过期缓存 + search 兜底返回 search 结果", list.map((r) => r.full_name), ["s2/skill-b"]);
+  check("search 兜底不改写缓存文件", readFileSync(cacheFile("dsh"), "utf8"), staleContent);
+  check("search 兜底不新增缓存文件", listCacheFiles(), ["dsh.json"]);
+}
+
+// ==================== 修复 2：readListCache 校验 ====================
+
+// 场景 C：有效缓存（generated_at 新鲜）+ search 也可用 → 缓存优先（不会退化到 search），
+//         且坏条目（full_name 非字符串/缺失/空串）被丢弃
+{
+  const validContent = JSON.stringify({
+    saved_at: new Date().toISOString(), generated_at: new Date().toISOString(), kind: "dsh", count: 4,
+    repos: [
+      cacheRepo("c2/good"),
+      { name: "no-full-name", stargazers_count: 9 },                       // 缺 full_name
+      { full_name: 123, stargazers_count: 9 },                             // full_name 非字符串
+      { full_name: "", stargazers_count: 9 },                              // full_name 空串
+    ],
+  }, null, 2);
+  writeFileSync(cacheFile("dsh"), validContent, "utf8");
+  const orig = mockFetch(null, searchItems(["s3/skill-c"]));
+  const list = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("有效缓存优先于 search 且坏条目丢弃", list.map((r) => r.full_name), ["c2/good"]);
+}
+
+// 场景 D：generated_at 过期 → 视为无效，走 search
+{
+  writeFileSync(cacheFile("dsh"), JSON.stringify({ saved_at: OLD, generated_at: OLD, kind: "dsh", count: 1, repos: [cacheRepo("c3/old")] }), "utf8");
+  const orig = mockFetch(null, searchItems(["s4/skill-d"]));
+  const list = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("generated_at 过期缓存被拒绝走 search", list.map((r) => r.full_name), ["s4/skill-d"]);
+}
+
+// 场景 E：generated_at 缺失（旧格式 saved_at-only）→ 视为无效，走 search
+{
+  writeFileSync(cacheFile("dsh"), JSON.stringify({ saved_at: new Date().toISOString(), kind: "dsh", count: 1, repos: [cacheRepo("c4/oldfmt")] }), "utf8");
+  const orig = mockFetch(null, searchItems(["s5/skill-e"]));
+  const list = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("旧格式缓存（无 generated_at）被拒绝走 search", list.map((r) => r.full_name), ["s5/skill-e"]);
+}
+
+// 场景 F：repos 为空数组 → 视为无效，走 search
+{
+  writeFileSync(cacheFile("dsh"), JSON.stringify({ saved_at: new Date().toISOString(), generated_at: new Date().toISOString(), kind: "dsh", count: 0, repos: [] }), "utf8");
+  const orig = mockFetch(null, searchItems(["s6/skill-f"]));
+  const list = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("空 repos 缓存被拒绝走 search", list.map((r) => r.full_name), ["s6/skill-f"]);
+}
+
+// ==================== 正向对照：registry 成功才写盘，且写出的格式可被再次读取 ====================
+
+// 场景 G：registry 成功 → 落盘（带 generated_at）；随后 registry/search 全挂 → 缓存兜底生效
+{
+  rmSync(listCacheDir, { recursive: true, force: true });
+  const registryPayload = { repos: [cacheRepo("r1/good", { has_skill: true })], generated_at: new Date().toISOString() };
+  let orig = mockFetch(registryPayload, searchItems(["s7/skill-g"]));
+  const fromRegistry = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("registry 成功返回 registry 数据", fromRegistry.map((r) => r.full_name), ["r1/good"]);
+  // registry 分支的 writeListCache 是 fire-and-forget（不 await），轮询等落盘完成
+  check("registry 成功写入缓存文件", await waitFor(() => {
+    try { return typeof JSON.parse(readFileSync(cacheFile("dsh"), "utf8")).generated_at === "string"; } catch { return false; }
+  }), true);
+  const written = JSON.parse(readFileSync(cacheFile("dsh"), "utf8"));
+  check("缓存带 count", written.count, 1);
+  check("缓存内容为完整索引", written.repos.map((r) => r.full_name), ["r1/good"]);
+  // 全挂 → 新鲜缓存兜底
+  orig = mockFetch(null, null);
+  const fromDisk = await lib.fetchAllRepos("dsh");
+  globalThis.fetch = orig;
+  check("全挂时新鲜缓存兜底生效", fromDisk.map((r) => r.full_name), ["r1/good"]);
+}
+
+rmSync(home, { recursive: true, force: true });
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/tests/unit/install-scripts.test.mjs
+++ b/scripts/tests/unit/install-scripts.test.mjs
@@ -1,0 +1,59 @@
+// install.ps1 / install.sh 安装脚本注册幂等契约——静态断言（不执行脚本）。
+//
+// 契约（与 README 及真实环境 cordis.patch.yml 一致）：
+//   1) 追加条目的 id 必须是 dsh-plugin-marketplace（与包名一致，dsh 统一开头；
+//      历史不一致：README 曾写 plugin-marketplace，本机环境也曾用该 id）
+//   2) 追加条目的 name 必须是 dsh-plugin-marketplace（包名）
+//   3) 注册检测正则必须缩进感知（真实 patch 条目嵌套在 `- insert:` 下，
+//      `      name: ...` 前导空格；行首锚定 `^name:` 永远匹配不到 → 每次运行追加重复块）
+//   4) 两个脚本行为必须一致（sh 用 POSIX [[:space:]] 保 macOS BSD grep 兼容）
+//
+// 静态断言跨平台、零依赖、秒级——固化防回归；行为验证见 integration/install-scripts.test.mjs。
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const sh = readFileSync(join(ROOT, "install.sh"), "utf8");
+const ps1 = readFileSync(join(ROOT, "install.ps1"), "utf8");
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+}
+
+// ---- 契约 1：追加条目 id 与包名一致（dsh-plugin-marketplace）----
+// 注意：`- id: plugin-marketplace` 是 `- id: dsh-plugin-marketplace` 的子串，
+// 必须用负向断言（后不跟 `-` 或词字符）区分，防止子串误判。
+check("sh 追加条目 id 为 dsh-plugin-marketplace", /- id: dsh-plugin-marketplace/.test(sh), true);
+check("sh 追加条目 id 非独立 plugin-marketplace", !/- id: plugin-marketplace(?![-\w])/.test(sh), true);
+check("ps1 追加条目 id 为 dsh-plugin-marketplace", /- id: dsh-plugin-marketplace/.test(ps1), true);
+check("ps1 追加条目 id 非独立 plugin-marketplace", !/- id: plugin-marketplace(?![-\w])/.test(ps1), true);
+
+// ---- 契约 2：追加 name 为包名 ----
+check("sh 追加 name 为 dsh-plugin-marketplace", /name: dsh-plugin-marketplace/.test(sh), true);
+check("ps1 追加 name 为 dsh-plugin-marketplace", /name: dsh-plugin-marketplace/.test(ps1), true);
+
+// ---- 契约 3：检测正则缩进感知 ----
+check("sh 检测正则允许前导空白 ([[:space:]]*)", /\^\[\[:space:\]\]\*name:/.test(sh), true);
+check("ps1 检测正则允许前导空白 (\\s*)", /\^\\s\*name:/.test(ps1), true);
+// 防回归：行首锚定（^name:）会漏匹配嵌套缩进条目 → 每次运行追加重复块
+check("sh 无行首锚定回归", !/\^name:\[\[:space:\]\]/.test(sh) && !grepShLineAnchor(), true);
+check("ps1 无行首锚定回归", !/\^name:/.test(ps1.replace(/\^\\s\*name:/g, "")), true);
+
+function grepShLineAnchor() {
+  // sh 侧若出现 `grep ... '^name:` 或 `"^name:` 形式即视为回归
+  return /grep[^;]*['"]\^name:/.test(sh);
+}
+
+// ---- 契约 4：两脚本条目语义一致（id + name 序列相同）----
+const shEntry = /printf\s+'([^']*dsh-plugin-marketplace[^']*)'/.exec(sh);
+const ps1Entry = /\$entry = "([^"]*dsh-plugin-marketplace[^"]*)"/.exec(ps1);
+check("sh 条目含 insert 块", shEntry ? shEntry[1].includes("- insert:") : false, true);
+check("ps1 条目含 insert 块", ps1Entry ? ps1Entry[1].includes("- insert:") : false, true);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## 背景

安装/卸载链路的正确性修复集（真实场景暴露的 bug 逐项收口）：

1. **注册检测缩进感知 + 条目 id 统一**（install.ps1/install.sh）：patch 条目是 `- insert:` 块内的缩进行（`      name: ...`），旧版行首锚定无前导空白匹配 → 每次运行追加重复块；id 统一为 `dsh-plugin-marketplace`（与包名一致）
2. **卸载 location 精确相等放行**：多 skill/多预设仓库安装时 location 记为 SKILLS_DIR/PRESETS_DIR 本身（无尾分隔符）——前缀校验恒 false → rm 被跳过、目录残留而记录已删
3. **search 兜底不写盘 + 缓存 generated_at 校验**：Search API 单 query 上限 1000 条（残缺结果只作当次响应，绝不落盘污染好缓存）；磁盘缓存写入带 generated_at，读取按 REGISTRY_MAX_AGE_MS 校验新鲜度
4. **卸载保留非 insert 顶层内容**：卸载最后一个插件不再清空 skin 块等非 insert 顶层内容
5. **测试工程化随附**：install-scripts 沙箱 fixture 化 + 并行化（install.ps1 本地运行复制整个仓库 ~90s/次 → 最小 fixture 目录 KB 级）+ 契约测试

## 测试

- install-scripts 静态断言 + 沙箱行为测试（全新/嵌套条目/连跑 3 次幂等）
- e2e 缓存场景（网络全挂回退内置索引/磁盘缓存兜底/搜索兜底不污染缓存，fixtures 带 generated_at）

## 说明

- install.ps1 的 `$PSNativeCommandUseErrorActionPreference` 修复与缩进感知检测上游已自行实现，本 PR 保留差异部分（id 统一）
- 部分集成测试（list-cache 的 bundled 隔离）依赖后续测试工程化 PR，此处以功能 + e2e 验证为准
