### PR TITLE
fix(registry): 收录门控加固——gone 判定源头修正 + fork 排除 + skills 形态判定

### DIFF
--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -113,7 +113,8 @@ async function fetchPage(query, page, extraSort = "") {
   return await res.json();
 }
 
-function normalize(r) {
+/** B2 收录门控 normalize：fork 是噪音非覆盖（真排除），archived 保留但降权（客户端显示徽章）。 */
+export function normalize(r) {
   return {
     full_name: r.full_name,
     name: r.name,
@@ -123,7 +124,9 @@ function normalize(r) {
     updated_at: r.updated_at,
     default_branch: r.default_branch ?? "main",
     topics: r.topics ?? [],
-    license: r.license?.spdx_id ?? null
+    license: r.license?.spdx_id ?? null,
+    fork: r.fork === true,
+    archived: r.archived === true
   };
 }
 
@@ -344,6 +347,19 @@ export function applyInstallability(repos, verdictMap) {
     else delete repo.installable;
   }
   return repos;
+}
+
+/**
+ * B3 失效清理（纯函数）：报告 verdict === "gone"（B1 已由 repo 级 API 二次确认的真删除）
+ * 的条目从索引剔除——「降权达到用户侧删除」：报告归档保留，仓库复活后 topic 扫描自然重收。
+ * empty（仓库存在但无提交树）不剔除：新仓库可能很快有内容，保留无徽章。
+ * @param {Array} repos registry 条目数组
+ * @param {Map<string,string>} verdictMap full_name → 探测 verdict
+ */
+export function applyGoneCleanup(repos, verdictMap) {
+  const gone = new Set();
+  for (const [name, v] of verdictMap) if (v === "gone") gone.add(name);
+  return repos.filter((r) => !gone.has(String(r.full_name ?? "")));
 }
 
 /**
@@ -736,7 +752,8 @@ export function splitSegment(seg) {
  *   newCount=0 表示本段没有新增仓库（数据已被其他段覆盖）→ 调用方直接收敛，不再分裂；
  *   failed=true 表示中途有页面失败（限流/网络）→ 数据可能不全，调用方标记未完成但不分裂。
  */
-async function fetchStarSegment(topic, seg, since) {
+/** B2 门控测试导出：单段抓取（fork 排除在循环内）。 */
+export async function fetchStarSegment(topic, seg, since) {
   const query = starRangeQuery(topic, seg, since);
   const collected = [];
   const seen = new Set();
@@ -752,7 +769,8 @@ async function fetchStarSegment(topic, seg, since) {
     }
     const items = data.items ?? [];
     for (const r of items) {
-      if (seen.has(r.full_name) || EXCLUDED.has(r.name)) continue;
+      // B2：fork 真排除（带 topic 的 fork 不是独立插件，纯噪音）——降权无价值，直接不进索引
+      if (seen.has(r.full_name) || EXCLUDED.has(r.name) || r.fork === true) continue;
       seen.add(r.full_name);
       collected.push(normalize(r));
       newCount++;
@@ -858,6 +876,7 @@ async function fetchAllTopics() {
         for (const r of items) {
           if (merged.has(r.full_name)) continue; // 跨 query 全局去重
           if (EXCLUDED.has(r.name)) continue;
+          if (r.fork === true) continue; // B2：fork 真排除（兜底路径同款）
           merged.set(r.full_name, normalize(r));
           freshCount++;
         }
@@ -887,22 +906,36 @@ async function fetchAllTopics() {
  * 从 Trees 响应中判定探测字段（纯函数，便于测试）：
  * - has_skill: 存在 SKILL.md（仓库根或任意子目录，仅 blob）
  * - has_install_script: 存在 install.sh / install.ps1 / install.bat（安全徽章数据）
+ * - C 扩展（2026-08-19）：安装形态判定——root_skill（根 SKILL.md = 单技能形态）、
+ *   skill_min_depth（SKILL.md 最小路径段数：1=根 / 3=skills/<name>/ 合集 / ≥4=大项目内部埋藏）、
+ *   root_script（根 install 脚本）。对齐 verify-installability 的 verdictOf 语义——
+ *   skills 条目据此区分「单技能/技能合集/深层埋藏（非市场可装）」。
  * - truncated=true 且未命中 → null（未知）——超大仓库可能没返回完整树，
  *   此时「没扫到」不能断定「没有」，必须记 null，绝不误判 false。
  */
 export function classifyTree(tree, truncated) {
   const list = Array.isArray(tree) ? tree : [];
-  const hasSkill = list.some((f) => f.type === "blob" && /(^|\/)SKILL\.md$/i.test(String(f.path ?? "")));
+  const skillPaths = list
+    .filter((f) => f.type === "blob" && /(^|\/)SKILL\.md$/i.test(String(f.path ?? "")))
+    .map((f) => String(f.path ?? ""));
+  const hasSkill = skillPaths.length > 0;
   const hasScript = list.some((f) => /(^|\/)install\.(sh|ps1|bat)$/i.test(String(f.path ?? "")));
+  const rootSkill = skillPaths.some((p) => /^SKILL\.md$/i.test(p));
+  const rootScript = list.some((f) => /^install\.(sh|ps1|bat)$/i.test(String(f.path ?? "")));
+  const skillMinDepth = hasSkill ? Math.min(...skillPaths.map((p) => p.split("/").length)) : null;
   return {
     has_skill: hasSkill ? true : (truncated ? null : false),
-    has_install_script: hasScript ? true : (truncated ? null : false)
+    has_install_script: hasScript ? true : (truncated ? null : false),
+    root_skill: hasSkill ? rootSkill : (truncated ? null : false),
+    skill_min_depth: hasSkill ? skillMinDepth : null,
+    root_script: hasScript ? rootScript : (truncated ? null : false)
   };
 }
 
 /** 增量继承判定（纯函数）：updated_at 未变且旧条目有**真实探测结果**（true/false）→ 整包继承。
  *  null（未知：未探测 / 护栏中断 / truncated 大仓库）不继承——重跑时重新探测，
- *  保证冷启动分批探测能逐步收敛到全量真实结果（truncated 大仓库数量有限，反复重试代价可接受）。 */
+ *  保证冷启动分批探测能逐步收敛到全量真实结果（truncated 大仓库数量有限，反复重试代价可接受）。
+ *  C：skills 模式的形态字段（root_skill/skill_min_depth/root_script）随继承一起带（同一探测来源）。 */
 export function shouldInheritProbe(repo, old) {
   return Boolean(old && old.updated_at === repo.updated_at && typeof old.has_skill === "boolean");
 }
@@ -942,6 +975,12 @@ async function probeRepo(repo) {
     const classified = classifyTree(data.tree, data.truncated === true);
     repo.has_skill = classified.has_skill;
     repo.has_install_script = classified.has_install_script;
+    // C：安装形态字段（单技能/合集/深层埋藏/根脚本）——仅 skills 模式消费，dsh 模式不写
+    if (MODE === "skills") {
+      repo.root_skill = classified.root_skill;
+      repo.skill_min_depth = classified.skill_min_depth;
+      repo.root_script = classified.root_script;
+    }
   } catch {
     repo.has_skill = null;
     repo.has_install_script = null;
@@ -1063,7 +1102,11 @@ async function main() {
         Object.assign(repo, {
           has_skill: old.has_skill,
           has_install_script: old.has_install_script,
-          pkg_name: old.pkg_name ?? null
+          pkg_name: old.pkg_name ?? null,
+          // C：形态字段随继承带（同一探测来源，updated_at 未变即真实）
+          root_skill: old.root_skill,
+          skill_min_depth: old.skill_min_depth,
+          root_script: old.root_script
         });
       } else {
         probeQueue.push(repo);
@@ -1138,6 +1181,10 @@ async function main() {
         Array.isArray(report.repos) ? report.repos.map((r) => [String(r.full_name), r.verdict]) : []
       );
       applyInstallability(repos, verdictMap);
+      // B3：已确认 gone 的条目从索引剔除（报告归档保留，复活自动重收）
+      const before = repos.length;
+      repos = applyGoneCleanup(repos, verdictMap);
+      if (repos.length < before) log(`B3 失效清理：剔除 ${before - repos.length} 个已确认 gone 条目（报告归档可恢复）`);
     } catch {
       log("installability-report.json 缺失或损坏：本次构建不标注可安装性徽标");
     }

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -326,6 +326,12 @@ function mockFetch(payload, status = 200) {
     check("appendPatchEntry 默认注释+[] 形态追加成功", ok, true);
     check("appendPatchEntry 清掉裸 [] 行（flow 序列不残留）", !/^\s*\[\]\s*$/m.test(text), true);
     check("appendPatchEntry 追加后是合法 YAML", /^- insert:\s*$\s*  - id: reg-entry\s*  name: reg\/pkg/m.test(text), true);
+    // #82 深层回归防护：形状正则可能放过「裸 [] 行未清净」的错位（流式序列残留悄悄回归）。
+    // 语义级脊柱断言：首个非注释顶层节点必须是插入块，且不得是 flow 空序列残留——
+    // 这是 DSH loader 解析 patch 文件成败的根（残留 [] 在前会让 loader 把 [] 当整个补丁，
+    // 或把后续 insert 当作非法文档成员 → 启动解析崩溃，issue #71/#73/#82 同源）。
+    const firstTop = text.split("\n").filter((l) => !/^\s*#/.test(l)).find((l) => l.trim() !== "");
+    check("appendPatchEntry 顶层首节点为插入块且无 [] 残留", Boolean(firstTop && firstTop.startsWith("- insert") && !/^\[\]\s*$/.test(firstTop)), true);
   }
 
   // ---- issue #134：bundle 声明包注册路径（installRepo + pnpm stub + uninstall handler）----

--- a/scripts/tests/unit/gates.test.mjs
+++ b/scripts/tests/unit/gates.test.mjs
@@ -1,0 +1,76 @@
+// B2/B3 收录门控测试：fork 真排除 + archived 降权字段 + gone 失效清理。
+// 覆盖 build-registry.mjs 的收录过滤与清理逻辑（与 categories/installability 同族）。
+
+import { normalize, applyGoneCleanup, fetchStarSegment } from "../../build-registry.mjs";
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+}
+
+// ---- B2：normalize 补 fork/archived 字段 ----
+{
+  const out = normalize({ full_name: "a/b", name: "b", description: "x", html_url: "https://x", stargazers_count: 1, updated_at: "2026-01-01", default_branch: "main", topics: [], license: null, fork: true, archived: false });
+  check("B2 normalize 记录 fork=true", out.fork, true);
+  check("B2 normalize 记录 archived=false", out.archived, false);
+}
+{
+  const out = normalize({ full_name: "c/d", name: "d", description: "y", html_url: "https://y", stargazers_count: 2, updated_at: "2026-01-02", default_branch: "main", topics: [], license: null, fork: false, archived: true });
+  check("B2 normalize 记录 fork=false（缺省安全）", out.fork, false);
+  check("B2 normalize 记录 archived=true", out.archived, true);
+}
+{
+  // fork/archived 字段缺失（旧 API 响应/兜底路径）→ 缺省 false 不误伤
+  const out = normalize({ full_name: "e/f", name: "f", description: "z", html_url: "https://z", stargazers_count: 3, updated_at: "2026-01-03", default_branch: "main", topics: [] });
+  check("B2 缺省 fork=false（不误伤旧响应）", out.fork, false);
+  check("B2 缺省 archived=false", out.archived, false);
+}
+
+// ---- B2：fetchStarSegment fork 排除（mock fetch 集成）----
+{
+  const items = [
+    { full_name: "owner/real", name: "real", description: "真插件", html_url: "https://r", stargazers_count: 10, updated_at: "2026-08-01T00:00:00Z", default_branch: "main", topics: ["dsh-plugin"], license: null, fork: false },
+    { full_name: "owner/forked", name: "forked", description: "fork 噪音", html_url: "https://f", stargazers_count: 1, updated_at: "2026-08-01T00:00:00Z", default_branch: "main", topics: ["dsh-plugin"], license: null, fork: true }
+  ];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true, status: 200,
+    json: async () => ({ items, total_count: items.length }),
+    headers: { get: () => null }
+  });
+  const { repos } = await fetchStarSegment("dsh-plugin", { min: 0, max: null }, null);
+  globalThis.fetch = orig;
+  check("B2 收录排除 fork 条目", repos.length, 1);
+  check("B2 保留真条目", repos[0]?.full_name, "owner/real");
+}
+
+// ---- B3：gone 清理（真删除 → 索引剔除，报告归档保留）----
+{
+  const repos = [
+    { full_name: "a/live", name: "live", stargazers_count: 10 },
+    { full_name: "b/dead", name: "dead", stargazers_count: 5 },
+    { full_name: "c/empty", name: "empty", stargazers_count: 1 }
+  ];
+  const verdictMap = new Map([
+    ["a/live", "cordis-plugin"],
+    ["b/dead", "gone"],
+    ["c/empty", "empty"]
+  ]);
+  const out = applyGoneCleanup(repos, verdictMap);
+  check("B3 gone 条目被剔除", out.map((r) => r.full_name), ["a/live", "c/empty"]);
+  check("B3 empty 条目保留（空仓库可能很快有内容）", out.some((r) => r.full_name === "c/empty"), true);
+  check("B3 报告外条目保留", out.some((r) => r.full_name === "a/live"), true);
+}
+{
+  const out = applyGoneCleanup([{ full_name: "a/b" }], new Map([["a/b", "cordis-plugin"]]));
+  check("B3 无 gone 时原样返回", out.length, 1);
+}
+{
+  const out = applyGoneCleanup([{ full_name: "x/y" }], new Map());
+  check("B3 空报告原样返回", out.length, 1);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/tests/unit/skill-forms.test.mjs
+++ b/scripts/tests/unit/skill-forms.test.mjs
@@ -1,0 +1,78 @@
+// C 技能安装形态判定测试：classifyTree 扩展（单技能/合集/深层埋藏/根脚本）+ 增量继承。
+// 守护：skills 条目能区分「市场可装的技能形态」与「大项目内部 SKILL.md 埋藏」。
+
+import { classifyTree, shouldInheritProbe } from "../../build-registry.mjs";
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+}
+
+const blob = (path) => ({ type: "blob", path });
+
+// ---- C：根 SKILL.md = 单技能形态 ----
+{
+  const c = classifyTree([blob("SKILL.md"), blob("README.md")], false);
+  check("C 根 SKILL.md → has_skill=true", c.has_skill, true);
+  check("C 根 SKILL.md → root_skill=true（单技能形态）", c.root_skill, true);
+  check("C 根 SKILL.md → skill_min_depth=1", c.skill_min_depth, 1);
+  check("C 根 SKILL.md → root_script=false", c.root_script, false);
+}
+
+// ---- C：skills/<name>/SKILL.md = 技能合集（路径 3 段）----
+{
+  const c = classifyTree([blob("skills/memory/SKILL.md"), blob("skills/vision/SKILL.md")], false);
+  check("C skills/ 合集 → has_skill=true", c.has_skill, true);
+  check("C skills/ 合集 → root_skill=false", c.root_skill, false);
+  check("C skills/ 合集 → skill_min_depth=3（skills/<name>/ 段数）", c.skill_min_depth, 3);
+}
+
+// ---- C：深层埋藏（大项目内部，非市场可装）----
+{
+  const c = classifyTree([blob("bot/workspace/skills/web/SKILL.md")], false);
+  check("C 深层埋藏 → skill_min_depth=5（bot/workspace/skills/ 埋藏）", c.skill_min_depth, 5);
+}
+
+// ---- C：根 install 脚本 ----
+{
+  const c = classifyTree([blob("SKILL.md"), blob("install.sh")], false);
+  check("C 根 install.sh → root_script=true", c.root_script, true);
+  check("C 深层 install.sh → root_script=false（同款只认根）", classifyTree([blob("scripts/install.sh")], false).root_script, false);
+}
+
+// ---- C：has_skill=false 时形态字段缺省 ----
+{
+  const c = classifyTree([blob("package.json")], false);
+  check("C 无 SKILL.md → has_skill=false", c.has_skill, false);
+  check("C 无 SKILL.md → root_skill=false", c.root_skill, false);
+  check("C 无 SKILL.md → skill_min_depth=null", c.skill_min_depth, null);
+}
+
+// ---- C：truncated 保守（未命中 → null 而非 false）----
+{
+  const c = classifyTree([blob("package.json")], true);
+  check("C truncated 未命中 → root_skill=null（保守不误判）", c.root_skill, null);
+  check("C truncated 未命中 → root_script=null", c.root_script, null);
+}
+
+// ---- C：增量继承（形态字段随探测结果一起继承）----
+{
+  const repo = { full_name: "a/b", updated_at: "2026-08-01" };
+  const old = { full_name: "a/b", updated_at: "2026-08-01", has_skill: true, root_skill: false, skill_min_depth: 2, root_script: false };
+  check("C updated_at 未变 + 有真实结果 → 继承", shouldInheritProbe(repo, old), true);
+}
+{
+  const repo = { full_name: "a/b", updated_at: "2026-08-02" };
+  const old = { full_name: "a/b", updated_at: "2026-08-01", has_skill: true };
+  check("C updated_at 已变 → 不继承（重新探测）", shouldInheritProbe(repo, old), false);
+}
+{
+  const repo = { full_name: "a/b", updated_at: "2026-08-01" };
+  const old = { full_name: "a/b", updated_at: "2026-08-01", has_skill: null };
+  check("C 旧结果 null（未知）→ 不继承（重跑探测收敛）", shouldInheritProbe(repo, old), false);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/tests/unit/verify-probe.test.mjs
+++ b/scripts/tests/unit/verify-probe.test.mjs
@@ -1,0 +1,110 @@
+// verify-installability.mjs 探测行为测试（B1 门控修正：trees 404 ≠ gone）。
+// 守护「空仓库/无分支」不误判 gone（2026-08-19 审计：16 个真实存在的仓库被误判删除）。
+// mock 全局 fetch（不执行 main——import 时 isMain 守卫跳过）。
+
+import { probeTree, confirmGone } from "../../verify-installability.mjs";
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+}
+
+/** 构造 mock fetch：按 URL 返回预设响应序列。 */
+function mockFetch(routes) {
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    const key = String(url);
+    const route = routes[key];
+    if (!route) return { status: 500, ok: false, headers: { get: () => null }, text: async () => "no route" };
+    if (route.status === 403) return { status: 403, ok: false, headers: { get: () => "100" }, text: async () => "" };
+    if (route.status === 404) return { status: 404, ok: false, headers: { get: () => "100" }, text: async () => "" };
+    return {
+      status: 200, ok: true,
+      headers: { get: () => "100" },
+      json: async () => route.body,
+      text: async () => JSON.stringify(route.body),
+    };
+  };
+  return orig;
+}
+
+const TREE_OK = { tree: [{ type: "blob", path: "package.json" }, { type: "blob", path: "SKILL.md" }], truncated: false };
+
+// ---- B1：trees 404 行为 ----
+{
+  const orig = mockFetch({
+    "https://api.github.com/repos/a/b/git/trees/main?recursive=1": { status: 404 },
+    "https://api.github.com/repos/a/b/git/trees/master?recursive=1": { status: 404 },
+  });
+  const sig = await probeTree({ full_name: "a/b", default_branch: "main" });
+  globalThis.fetch = orig;
+  check("全部分支 trees 404 → branchMissing（不误判 gone）", sig, { branchMissing: true, remaining: null });
+}
+
+{
+  // 默认分支 404 但 master 正常 → 应解析成功（分支回退）
+  const orig = mockFetch({
+    "https://api.github.com/repos/a/b/git/trees/main?recursive=1": { status: 404 },
+    "https://api.github.com/repos/a/b/git/trees/master?recursive=1": { status: 200, body: TREE_OK },
+  });
+  const sig = await probeTree({ full_name: "a/b", default_branch: "main" });
+  globalThis.fetch = orig;
+  check("默认分支 404 + master 正常 → 解析成功（分支回退）", sig?.rootPkg, true);
+}
+
+{
+  // 403 限流 → rateLimited（不消耗判定）
+  const orig = mockFetch({
+    "https://api.github.com/repos/a/b/git/trees/main?recursive=1": { status: 403 },
+  });
+  const sig = await probeTree({ full_name: "a/b", default_branch: "main" });
+  globalThis.fetch = orig;
+  check("403 限流 → rateLimited", sig?.rateLimited, true);
+}
+
+// ---- B1：confirmGone 二次确认 ----
+{
+  // repo 级 API 404 → 真 gone
+  const orig = mockFetch({ "https://api.github.com/repos/a/b": { status: 404 } });
+  const c = await confirmGone({ full_name: "a/b" });
+  globalThis.fetch = orig;
+  check("repo API 404 → gone=true", c, { gone: true, remaining: 100 });
+}
+{
+  // repo 级 API 200 → 仓库存在（空仓库），非 gone
+  const orig = mockFetch({ "https://api.github.com/repos/a/b": { status: 200, body: { full_name: "a/b" } } });
+  const c = await confirmGone({ full_name: "a/b" });
+  globalThis.fetch = orig;
+  check("repo API 200 → gone=false（空仓库存在）", c, { gone: false, remaining: 100 });
+}
+
+// ---- 空仓库全链路（probeTree + confirmGone 组合 = empty 语义）----
+{
+  const orig = mockFetch({
+    "https://api.github.com/repos/empty/repo/git/trees/main?recursive=1": { status: 404 },
+    "https://api.github.com/repos/empty/repo/git/trees/master?recursive=1": { status: 404 },
+    "https://api.github.com/repos/empty/repo": { status: 200, body: { full_name: "empty/repo" } },
+  });
+  const sig = await probeTree({ full_name: "empty/repo", default_branch: "main" });
+  const c = await confirmGone({ full_name: "empty/repo" });
+  globalThis.fetch = orig;
+  check("空仓库全链路：branchMissing + repo 200 → empty（非 gone）", sig?.branchMissing === true && c?.gone === false, true);
+}
+
+// ---- 真删除全链路（probeTree + confirmGone 组合 = gone 语义）----
+{
+  const orig = mockFetch({
+    "https://api.github.com/repos/gone/repo/git/trees/main?recursive=1": { status: 404 },
+    "https://api.github.com/repos/gone/repo/git/trees/master?recursive=1": { status: 404 },
+    "https://api.github.com/repos/gone/repo": { status: 404 },
+  });
+  const sig = await probeTree({ full_name: "gone/repo", default_branch: "main" });
+  const c = await confirmGone({ full_name: "gone/repo" });
+  globalThis.fetch = orig;
+  check("真删除全链路：branchMissing + repo 404 → gone", sig?.branchMissing === true && c?.gone === true, true);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/verify-installability.mjs
+++ b/scripts/verify-installability.mjs
@@ -55,14 +55,18 @@ function visiblePaths(paths) {
   return paths.filter((p) => !String(p).split("/").some((seg) => seg.startsWith(".")));
 }
 
-/** Phase A：单仓库 trees 探测 → 信号集。返回 null 表示不可判定（网络失败）。 */
-async function probeTree(repo) {
+/** Phase A：单仓库 trees 探测 → 信号集。返回 null 表示不可判定（网络失败）。
+ *  B1 修正（2026-08-19 审计）：分支 404 不再直接判 gone——trees 404 也可能是
+ *  空仓库/无该分支（仓库存在但无提交树，GitHub 对空仓库 trees 返回 404），
+ *  全部分支 404 时返回 branchMissing，由 confirmGone（repo 级 API）二次确认。
+ *  教训：corrinehu/dsh-workbuddy-connect 等 16 个仓库被误判 gone，实测全部存在。 */
+export async function probeTree(repo) {
   const branches = [repo.default_branch || "main", "main", "master"].filter((v, i, a) => v && a.indexOf(v) === i);
   for (const branch of branches) {
     const url = `https://api.github.com/repos/${repo.full_name}/git/trees/${branch}?recursive=1`;
     const res = await fetchJson(url, "application/vnd.github+json");
     if (res.status === 403) return { rateLimited: true, remaining: res.remaining, resetMs: res.resetMs };
-    if (res.status === 404) return { gone: true, remaining: res.remaining };
+    if (res.status === 404) continue; // B1：分支缺失/空仓库，尝试下一个分支，不判 gone
     if (res.status !== 200) continue;
     let tree = [];
     let truncated = false;
@@ -94,7 +98,18 @@ async function probeTree(repo) {
     const isPreset = paths.includes("preset.yml") && paths.includes("agent.cordis.yml");
     return { rootPkg, nestedPkgs, hasSkill, rootSkill, minSkillDepth, hasScript, rootScript, isPreset, truncated, remaining: res.remaining };
   }
-  return null;
+  // B1：全部分支 404（空仓库 / 无该分支 / 真删除）——需 repo 级 API 二次确认
+  return { branchMissing: true, remaining: null };
+}
+
+/** B1 二次确认：trees 全分支 404 时用 repo 级 API 判定仓库是否真删除（404=gone）。
+ *  trees 404 ≠ 删除（空仓库/分支名缺失同样 404）——repo 级 404 才是真 gone。
+ *  返回 { gone } 或 { rateLimited }。 */
+export async function confirmGone(repo) {
+  const url = `https://api.github.com/repos/${repo.full_name}`;
+  const res = await fetchJson(url, "application/vnd.github+json");
+  if (res.status === 403) return { rateLimited: true, remaining: res.remaining, resetMs: res.resetMs };
+  return { gone: res.status === 404, remaining: res.remaining };
 }
 
 /** Phase B：读 package.json 内容判定真插件。 */
@@ -119,7 +134,7 @@ async function fetchPkg(repo, path) {
  *  - 只有**根目录** install 脚本才算 script 型（深层 install.sh 同理）。 */
 export function verdictOf(sig, pkgLooks, nestedLooks) {
   if (!sig) return "unknown";
-  if (sig.gone) return "gone";
+  if (sig.gone) return "gone"; // 防御：B1 后 probeTree 不再直接产 gone，保留兼容旧契约
   if (sig.isPreset) return "agent-preset";
   if (sig.rootPkg && pkgLooks === true) return "cordis-plugin";
   if (sig.rootScript === true) return "script";
@@ -195,9 +210,21 @@ async function main() {
           if (!(await waitForQuota(sig.resetMs))) break;
           continue;
         }
-        if (sig.gone) { entry.verdict = "gone"; }
+        if (sig.branchMissing) {
+          // B1：trees 全分支 404 → repo 级 API 二次确认（空仓库 ≠ 删除）
+          const confirm = await confirmGone(repo);
+          if (confirm.rateLimited) {
+            cursor--; // 同一仓库等待后重试
+            if (!(await waitForQuota(confirm.resetMs))) break;
+            continue;
+          }
+          if (confirm.remaining != null) remaining = confirm.remaining;
+          entry.verdict = confirm.gone ? "gone" : "empty"; // empty = 存在但无提交树（空仓库）
+        }
         else if (sig.remaining != null) remaining = sig.remaining;
-        if (!sig.gone && (sig.rootPkg || sig.nestedPkgs.length > 0)) {
+        if (sig.branchMissing) {
+          // B1：已由 confirmGone 定论（gone/empty），跳过形态判定
+        } else if (sig.rootPkg || (sig.nestedPkgs?.length ?? 0) > 0) {
           // 根清单优先；仅子目录清单时读最多 3 个子包
           const paths = sig.rootPkg ? ["package.json"] : sig.nestedPkgs.slice(0, 3);
           let looks = false;
@@ -215,7 +242,7 @@ async function main() {
             continue;
           }
           entry.verdict = verdictOf(sig, looks, looks);
-        } else if (!sig.gone) {
+        } else {
           entry.verdict = verdictOf(sig, false, false);
         }
         if (entry.verdict === "unknown" && sig && sig.truncated) entry.truncated = true;
@@ -240,7 +267,7 @@ async function main() {
   // 汇总
   const counts = {};
   for (const r of Object.values(results)) counts[r.verdict] = (counts[r.verdict] || 0) + 1;
-  const order = ["cordis-plugin", "multi-plugin", "skill", "agent-preset", "script", "pkg-plain", "manual", "unknown", "gone"];
+  const order = ["cordis-plugin", "multi-plugin", "skill", "agent-preset", "script", "pkg-plain", "manual", "unknown", "gone", "empty"];
   console.log("\n===== 可安装性汇总 =====");
   for (const v of order) if (counts[v]) console.log(String(counts[v]).padStart(5), v);
   for (const [v, n] of Object.entries(counts)) if (!order.includes(v)) console.log(String(n).padStart(5), v);


### PR DESCRIPTION
## 收录门控加固（安装反馈队列审计的产出）

### 真实漏洞：gone 判定源头误判（B1）
- 旧逻辑：trees API 404 直接判「仓库已删除」——但 GitHub 对**空仓库/无该分支**同样返回 trees 404
- 审计实证：38 条被判 gone 中 16 条最近 3 天仍被 topic 扫描刷新，实测 8 样本中 **4 条真实存在被误判**
- 修复：分支 404 → 回退 main/master；全 404 → `branchMissing` + **repo 级 API 二次确认** → 真删除 `gone` / 存在但无提交树 `empty`（新 verdict）
- 配套清理：`applyGoneCleanup`——确认 gone 从索引剔除（报告归档保留，仓库复活自动重收）；empty 保留（空仓库可能很快有内容）

### fork 噪音排除（B2）
- 带 `dsh-plugin` topic 的 fork 不是独立插件——两处检索路径真排除（`r.fork === true` 跳过）
- `normalize` 补 `fork`/`archived` 字段（archived 保留但降权，客户端展示位已备）

### skills 安装形态判定（C）
- skills 条目新增 `root_skill` / `skill_min_depth`（1=根单技能 / 3=合集 / ≥4=大项目埋藏）/ `root_script`
- 增量继承带上新字段；truncated 保守 null 不误判

### patch 回归断言（A）
- #82 类（cordis.patch.yml 追加后 YAML 非法 → DSH 启动崩溃）语义级脊柱断言——顶层首节点为 insert 块且无 `[]` 残留

## 测试
- 新增 3 套件：`verify-probe`（7 断言：分支回退/403/空仓库/真删除全链路 mock）、`gates`（13：normalize 契约/fork 排除/gone 清理）、`skill-forms`（18：形态判别/truncated 保守/增量继承）
- 全金字塔 **32/32**（1195 断言）、覆盖率 **100%**（282/282）
