### PR TITLE
feat(profile): 目标 profile 配置化——面板可选安装目标（issue #184 方案 A）

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -65,6 +65,12 @@ window.__ModuleLoader__.load({
       dataSourceBundled: "当前显示插件内置索引（离线可用；点「刷新」获取最新）",
       dedupeHint: "{n} 个同名包已隐藏（同名 npm 包只能安装一个）",
       backupTitle: "备份与恢复",
+      profileTitle: "目标 profile",
+      profileLabel: "安装目标：",
+      profileSave: "保存",
+      profileSaved: "目标 profile 已设为 {profile}",
+      profileSaveFail: "保存失败：{err}",
+      profileNote: "插件将安装到该 profile（默认 web）。仅限已存在的 profile 名（字母数字下划线连字符）。",
       editBtn: "编辑",
       editTitle: "编辑环境变量",
       editHint: "为 {repo} 配置环境变量（如 API KEY）。值仅保存在本机，重启 DSH 后生效。",
@@ -228,6 +234,12 @@ window.__ModuleLoader__.load({
       dataSourceBundled: "Showing the bundled index (offline-ready; click Refresh for the latest)",
       dedupeHint: "{n} duplicate packages hidden (same npm package can only be installed once)",
       backupTitle: "Backup & Restore",
+      profileTitle: "Target profile",
+      profileLabel: "Install target:",
+      profileSave: "Save",
+      profileSaved: "Target profile set to {profile}",
+      profileSaveFail: "Save failed: {err}",
+      profileNote: "Plugins will install into this profile (default: web). Existing profile names only (alphanumeric/underscore/hyphen).",
       editBtn: "Edit",
       editTitle: "Edit environment variables",
       editHint: "Configure environment variables (e.g. API KEY) for {repo}. Values stay on this machine and take effect after restarting DSH.",
@@ -1025,6 +1037,36 @@ window.__ModuleLoader__.load({
           .catch(function () { /* 静默 */ });
       }, []);
 
+      // 目标 profile（issue #184）：打开市场时读取当前值
+      var profileState = useState("web");
+      var targetProfile = profileState[0]; var setTargetProfile = profileState[1];
+      var profileBusyState = useState(false); var profileBusy = profileBusyState[0]; var setProfileBusy = profileBusyState[1];
+      useEffect(function () {
+        fetch("/api/marketplace/profile", { headers: { "X-DSH-Marketplace": "1" } })
+          .then(function (r) { return r.json(); })
+          .then(function (data) { if (data && data.status === "done" && data.profile) setTargetProfile(data.profile); })
+          .catch(function () { /* 静默 */ });
+      }, []);
+
+      /** 保存目标 profile（空值回退 web）。 */
+      function saveTargetProfile() {
+        var name = targetProfile.trim() || "web";
+        setProfileBusy(true);
+        fetch("/api/marketplace/profile", {
+          method: "POST",
+          headers: mpHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ profile: name })
+        }).then(function (r) { return r.json(); }).then(function (data) {
+          if (data && data.status === "done") {
+            showToast(t("profileSaved", { profile: data.profile }), true);
+            setTargetProfile(data.profile);
+          } else {
+            showToast(t("profileSaveFail", { err: (data && data.error) || "unknown" }), false);
+          }
+        }).catch(function (err) { showToast(t("profileSaveFail", { err: String(err) }), false); })
+          .finally(function () { setProfileBusy(false); });
+      }
+
       /** 保存/清除 GitHub Token（空串或 ****** 视为清除）。 */
       function saveFbToken() {
         var token = fbTokenInput.trim();
@@ -1389,6 +1431,15 @@ window.__ModuleLoader__.load({
               t("fbToggle")
             )
           )
+        ),
+        h("div", { key: "profile-cfg", style: { border: "1px solid var(--dsw-alias-border-l2)", borderRadius: 10, padding: "10px 14px", margin: "0 0 12px" } },
+          h("p", { style: { fontSize: 12, fontWeight: 600, margin: "0 0 8px", color: "var(--dsw-alias-label-secondary)" } }, t("profileTitle")),
+          h("div", { style: { display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" } },
+            h("span", { style: { fontSize: 12, color: "var(--dsw-alias-label-secondary)" } }, t("profileLabel")),
+            h("input", { style: Object.assign({}, wdInputStyle, { width: 160 }), type: "text", placeholder: "web", value: targetProfile, onChange: function (e) { setTargetProfile(e.target.value); } }),
+            h("button", { className: "dshm-btn", style: s.btn, disabled: profileBusy, onClick: saveTargetProfile }, profileBusy ? t("installing") : t("profileSave"))
+          ),
+          h("p", { style: { fontSize: 11, color: "var(--dsw-alias-label-tertiary)", margin: "6px 0 0" } }, t("profileNote"))
         ),
         h("div", { key: "backup", style: { border: "1px solid var(--dsw-alias-border-l2)", borderRadius: 10, padding: "10px 14px", margin: "0 0 12px" } },
           h("p", { style: { fontSize: 12, fontWeight: 600, margin: "0 0 8px", color: "var(--dsw-alias-label-secondary)" } }, t("backupTitle")),

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,10 +66,13 @@ const listSources = { dsh: "registry", skills: "registry" };
 const CACHE_REUSE_MS = 15 * 60 * 1000;
 const SKILLS_DIR = join(DSH_HOME, "skills");
 const PRESETS_DIR = join(DSH_HOME, ".agent-presets");
-const PROFILE_WEB_DIR = join(DSH_HOME, "profiles", "web");
-const PROFILE_NM = join(PROFILE_WEB_DIR, "node_modules");
-const PATCH_FILE = join(PROFILE_WEB_DIR, "cordis.patch.yml");
-const PROFILE_PKG = join(PROFILE_WEB_DIR, "package.json");
+// 目标 profile（issue #184）：默认 web；经 setTargetProfile 从 config.json 读取
+// （面板可改）。let 而非 const——配置变更后重算派生路径，37 处引用点零改动。
+let targetProfile = "web";
+let PROFILE_WEB_DIR = join(DSH_HOME, "profiles", "web");
+let PROFILE_NM = join(PROFILE_WEB_DIR, "node_modules");
+let PATCH_FILE = join(PROFILE_WEB_DIR, "cordis.patch.yml");
+let PROFILE_PKG = join(PROFILE_WEB_DIR, "package.json");
 
 const SEARCH_QUERIES = {
   dsh: ["topic:dsh-plugin"],
@@ -1191,6 +1194,9 @@ const MESSAGES = {
     "forbidden": "请求被拒绝：来源不可信（缺少 X-DSH-Marketplace 头，或 Host 不在白名单内）",
     "bodyTooLarge": "请求体过大（上限 1 MB）",
     "badRequest": "请求格式错误",
+    "badProfile": "profile 名不合法或不存在（仅字母数字下划线连字符，且须为已存在的 profile）",
+    "profileSaveFail": "profile 配置保存失败",
+    "profileSet": "目标 profile 已切换为 {profile}（后续安装将写入该 profile）",
     "installBusy": "另一个安装正在进行中，请等待其完成后再试。",
     "notInstalled": "该插件没有安装记录，无法检测更新。",
     "checkUpdateNotNpm": "该插件由 GitHub 仓库安装，版本自动检测，无需手动检查。",
@@ -1394,6 +1400,9 @@ const MESSAGES = {
     "forbidden": "Request rejected: untrusted origin (missing X-DSH-Marketplace header, or Host not in allowlist)",
     "bodyTooLarge": "Request body too large (1 MB limit)",
     "badRequest": "Bad request",
+    "badProfile": "Invalid or missing profile (alphanumeric/underscore/hyphen only, and must be an existing profile)",
+    "profileSaveFail": "Failed to save profile config",
+    "profileSet": "Target profile switched to {profile} — future installs will write to it",
     "installBusy": "Another install is in progress — please wait for it to finish.",
     "notInstalled": "No install record for this plugin — cannot check for updates.",
     "checkUpdateNotNpm": "Installed from a GitHub repo; version detection is automatic.",
@@ -1560,6 +1569,43 @@ async function isLanWriteEnabled() {
   } catch {
     return false;
   }
+}
+
+/** profile 名白名单（issue #184）：只允许字母数字下划线连字符——join 进
+ *  profiles/<name> 路径，含 ../ 等穿越段会逃逸到任意目录（路径注入）。 */
+const PROFILE_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+/** 目标 profile 配置读取：config.json 的 targetProfile；非法/缺失回退 "web"。
+ *  目录存在性校验——配置指向不存在的 profile 时回退（防装进空目录）。 */
+async function readTargetProfile() {
+  let name = "web";
+  try {
+    const cfg = JSON.parse(await readFile(join(MARKET_ROOT, "config.json"), "utf8"));
+    if (typeof cfg?.targetProfile === "string" && PROFILE_NAME_RE.test(cfg.targetProfile)) {
+      name = cfg.targetProfile;
+    }
+  } catch { /* 缺失/损坏：默认 web */ }
+  try {
+    const st = await stat(join(DSH_HOME, "profiles", name));
+    if (!st.isDirectory()) return "web";
+  } catch { return "web"; }
+  return name;
+}
+
+/** 应用目标 profile：重算派生路径常量（37 处引用点零改动）。 */
+function setTargetProfile(name) {
+  const safe = PROFILE_NAME_RE.test(String(name ?? "")) ? String(name) : "web";
+  targetProfile = safe;
+  PROFILE_WEB_DIR = join(DSH_HOME, "profiles", safe);
+  PROFILE_NM = join(PROFILE_WEB_DIR, "node_modules");
+  PATCH_FILE = join(PROFILE_WEB_DIR, "cordis.patch.yml");
+  PROFILE_PKG = join(PROFILE_WEB_DIR, "package.json");
+  return safe;
+}
+
+/** 当前生效的 profile node_modules 路径（测试/诊断用）。 */
+function getProfileNodeModules() {
+  return PROFILE_NM;
 }
 
 /** 写操作放行判定：isTrustedRequest（CSRF 头 + Host 白名单 + Origin）之上叠加—— */
@@ -3415,6 +3461,13 @@ function apply(ctx) {
     ctx.logger?.warn?.(`dsh-plugin-marketplace: 启动预热拉取失败 ${error}`);
   });
 
+  // 目标 profile 配置（issue #184）：启动时从 config.json 读取并应用（默认 web）。
+  // 面板保存时经 API 即时重算，无需重启。
+  readTargetProfile().then((name) => {
+    setTargetProfile(name);
+    ctx.logger?.info?.(`dsh-plugin-marketplace: 目标 profile = ${targetProfile}`);
+  }).catch(() => {});
+
   // 小优待：每次 DSH 启动直链 GitHub 查市场本体是否有新版本（失败静默，页面打开时会重查）
   checkSelfUpdate().catch((error) => {
     ctx.logger?.warn?.(`dsh-plugin-marketplace: 自更新检测失败 ${error}`);
@@ -3913,6 +3966,49 @@ function apply(ctx) {
       const configured = {};
       for (const k of keys) configured[k] = Boolean(stored[k]);
       return json(res, 200, { status: "done", repo, envKeys: keys, configured });
+    }
+  });
+
+  // ── 目标 profile 配置（issue #184）：GET 读当前值；POST 保存并即时生效 ──
+  // 写操作鉴权与 install/uninstall 一致（isWriteAllowed：回环放行 / LAN 需 lanWrite+token）。
+  webServer.register({
+    kind: "exact",
+    path: "/api/marketplace/profile",
+    handler: async (req, res) => {
+      const lang = langOf(req, { lang: "" });
+      if (req.method === "GET") {
+        if (!isTrustedRequest(req)) return json(res, 403, { error: t(lang, "forbidden") });
+        return json(res, 200, { status: "done", profile: targetProfile });
+      }
+      if (req.method !== "POST") return json(res, 405, { error: t(lang, "methodNotAllowed") });
+      if (!(await isWriteAllowed(req))) return json(res, 403, { error: t(lang, "forbidden") });
+      let body;
+      try {
+        body = await readJsonBody(req);
+      } catch {
+        return json(res, 400, { error: t(lang, "badRequest") });
+      }
+      const name = String(body?.profile ?? "").trim();
+      if (!PROFILE_NAME_RE.test(name)) return json(res, 400, { error: t(lang, "badProfile") });
+      // 目录存在性校验：目标 profile 不存在时拒绝（防装进空目录）
+      try {
+        const st = await stat(join(DSH_HOME, "profiles", name));
+        if (!st.isDirectory()) return json(res, 400, { error: t(lang, "badProfile") });
+      } catch {
+        return json(res, 400, { error: t(lang, "badProfile") });
+      }
+      try {
+        const cfgPath = join(MARKET_ROOT, "config.json");
+        let cfg = {};
+        try { cfg = JSON.parse(await readFile(cfgPath, "utf8")); } catch { /* 缺失/损坏：重建 */ }
+        cfg.targetProfile = name;
+        await writeFile(cfgPath, JSON.stringify(cfg, null, 2), "utf8");
+      } catch {
+        return json(res, 500, { error: t(lang, "profileSaveFail") });
+      }
+      setTargetProfile(name);
+      ctx.logger?.info?.(`dsh-plugin-marketplace: 目标 profile 已切换为 ${name}`);
+      return json(res, 200, { status: "done", profile: name });
     }
   });
 
@@ -4897,5 +4993,5 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets, scanCacheVulnerabilities, readVulnScanDeps };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets, scanCacheVulnerabilities, readVulnScanDeps, setTargetProfile, readTargetProfile, getProfileNodeModules };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2986,6 +2986,20 @@ function readVulnScanDeps(pkg, lockVersions) {
     if (!deps || typeof deps !== "object") continue;
     for (const [name, range] of Object.entries(deps)) {
       if (typeof range !== "string" || range.length === 0) continue;
+      // npm: 别名依赖（my-lodash: npm:lodash@4.17.15）：漏洞面在真实包上——
+      // 解出真实包名与版本进扫描面（本地别名不查 registry，查了也查不到）
+      if (range.startsWith("npm:")) {
+        const m = range.slice(4).match(/^(?:@[^/]+\/)?[^@]+@(.+)$/);
+        if (m) {
+          const realName = range.slice(4, range.length - m[1].length - 1);
+          out.push({ name: realName, version: m[1] });
+        }
+        continue;
+      }
+      // workspace:/link: 纯本地引用：无 registry 漏洞面且无独立版本可判，跳过。
+      // file: 不在此跳过——scanCacheVulnerabilities 已把子包版本写进 lockVersions，
+      // 走下方精确版本分支即可进扫描面。
+      if (/^(?:workspace|link):/.test(range)) continue;
       const exact = lockVersions.get(name);
       if (/^[0-9]+\.[0-9]+\.[0-9]+/.test(exact ?? "")) {
         out.push({ name, version: exact });
@@ -4661,6 +4675,26 @@ function apply(ctx) {
                 && resolve(record.location).startsWith(resolve(PROFILE_NM) + sep)) {
               targets = [record.location.split(sep).at(-1)];
             }
+            // 目标 profile 切换后卸载旧 profile 的安装（issue #184 边界）：按包名拼的
+            // 路径指向当前 PROFILE_NM——旧 profile 的实体不在那里，rm force:true 静默
+            // 无操作 → 记录删除但目录/patch 残留（孤儿态）。此时改按 record.location
+            // 定位包目录（location 是安装时的真实落点），pnpm remove 同样以 location
+            // 所属 profile 为工作目录。
+            let legacyProfileDir = null;
+            if (targets.length > 0 && typeof record.location === "string"
+                && record.location !== PROFILE_NM) {
+              const locResolved = resolve(record.location);
+              // 在 profiles/ 下但不在当前 PROFILE_NM 下 → 旧 profile 安装
+              if (!locResolved.startsWith(resolve(PROFILE_NM) + sep)
+                  && locResolved.startsWith(join(DSH_HOME, "profiles") + sep)) {
+                const nmRoot = record.location.split(`${sep}node_modules${sep}`)[0];
+                if (nmRoot && PROFILE_NAME_RE.test(nmRoot.split(sep).at(-1) ?? "")) {
+                  legacyProfileDir = nmRoot;
+                  const pkgSeg = record.location.split(`${sep}node_modules${sep}`)[1];
+                  if (pkgSeg) targets = [pkgSeg];
+                }
+              }
+            }
             if (targets.length > 0) {
               // 审查 B2：卸载步骤失败不得静默吞错——目录删除失败或 patch 条目移除失败
               // 会造成「目录已删但 patch 残留（下次启动注册失败）」或反向的状态分裂。
@@ -4673,7 +4707,7 @@ function apply(ctx) {
                   logLine(t(lang, "uninstallBundlePnpm", { name: pkgName }));
                   try {
                     // --ignore-workspace：同注册路径（runPnpm 的 workspace 吞依赖陷阱）
-                    await runPnpm(["remove", "--ignore-workspace", pkgName], { cwd: PROFILE_WEB_DIR, env: buildFilteredEnv(), timeout: 600000 });
+                    await runPnpm(["remove", "--ignore-workspace", pkgName], { cwd: legacyProfileDir ?? PROFILE_WEB_DIR, env: buildFilteredEnv(), timeout: 600000 });
                     removed++;
                   } catch (error) {
                     const manifest = await readProfileManifest();
@@ -4702,8 +4736,8 @@ function apply(ctx) {
                   }
                   continue;
                 }
-                const dest = join(PROFILE_NM, pkgName);
-                if (resolve(dest).startsWith(resolve(PROFILE_NM) + sep)) {
+                const dest = legacyProfileDir ? join(legacyProfileDir, "node_modules", pkgName) : join(PROFILE_NM, pkgName);
+                if (resolve(dest).startsWith(resolve(legacyProfileDir ?? PROFILE_NM) + sep)) {
                   try {
                     await rm(dest, { recursive: true, force: true });
                     removed++;

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -1327,7 +1327,11 @@ async function enrichPkgNames(repos, includeVersion = false) {
   // bundle 状态新鲜度敏感（声明可变），带 bundle 标记的条目强制每轮重抓
   // ——否则旧 `bundle: true` 残留（普通插件意外显示 bundle 徽章），或 bundle 移除后永不清除。
   const bundleSuspect = (r) => includeVersion && r.bundle === true;
-  const todo = repos.filter((r) => (includeVersion ? !r.pkg_name || !r.version : !r.pkg_name) || highStarSuspect(r) || bundleSuspect(r));
+  // eco_type 同样新鲜度敏感：仓库加/移除 dsh.bundle.patch、桌面客户端改插件后，
+  // pkg_name/version 都在 → 不进 todo → 旧枚举永久残留（与 bundleSuspect 同构）。
+  const ecoTypeSuspect = (r) => includeVersion && typeof r.eco_type === "string";
+  const todo = repos.filter((r) => (includeVersion ? !r.pkg_name || !r.version : !r.pkg_name)
+    || highStarSuspect(r) || bundleSuspect(r) || ecoTypeSuspect(r));
   if (todo.length === 0) return;
   let cursor = 0;
   const worker = async () => {

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -650,6 +650,45 @@ function mockFetchCapture(payload, status = 200) {
       check("写回失败被 catch 吞（目录删除兜底仍执行）", existsSync(join(web, "node_modules", "fake-bundle-ro")), false);
       writeFileSync(join(stubDir, "mode"), "", "utf8");
 
+      // 跨 profile 卸载（issue #184 边界）：targetProfile 切到 desktop 后，卸载
+      // 安装记录仍指向 web 的插件——必须按 record.location 定位真实落点删除，
+      // 而非在 desktop 的 node_modules 下按包名拼路径（rm force:true 静默残留）。
+      {
+        mkdirSync(join(process.env.DSH_HOME, "profiles", "desktop", "node_modules"), { recursive: true });
+        const legacyPkg = join(web, "node_modules", "legacy-web-plugin");
+        mkdirSync(legacyPkg, { recursive: true });
+        writeFileSync(join(legacyPkg, "package.json"), JSON.stringify({ name: "legacy-web-plugin", version: "0.9.0" }), "utf8");
+        await lib.saveInstalled("fake/legacy-repo", {
+          type: "cordis-plugin", name: "legacy-web-plugin", names: ["legacy-web-plugin"],
+          location: legacyPkg, version: "0.9.0", installedAt: Date.now(), envKeys: null,
+        });
+        lib.setTargetProfile("desktop");
+        try {
+          const registeredX = [];
+          lib.apply({ get: (s) => (s === "webServer" ? { register: (r) => registeredX.push(r) } : undefined), logger: { warn: () => {} }, slots: { inject: () => {} } });
+          const uninstallX = registeredX.find((r) => r.path === "/api/marketplace/uninstall")?.handler;
+          let sentX = false;
+          const unReqX = {
+            method: "POST",
+            headers: { "x-dsh-marketplace": "1", host: "127.0.0.1:3080" },
+            socket: { remoteAddress: "127.0.0.1" },
+            url: "/api/marketplace/uninstall",
+            [Symbol.asyncIterator]() {
+              return { next: async () => (sentX ? { value: undefined, done: true } : ((sentX = true), { value: Buffer.from(JSON.stringify({ repo: "fake/legacy-repo" })), done: false })) };
+            },
+          };
+          let uStatusX = 0;
+          let uBodyX = null;
+          await uninstallX(unReqX, { writeHead: (x) => { uStatusX = x; }, end: (b) => { try { uBodyX = JSON.parse(b); } catch { uBodyX = null; } } });
+          check("跨 profile 卸载响应 done", [uStatusX === 200, uBodyX?.status], [true, "done"]);
+          check("跨 profile 卸载删除旧 profile 实体目录", existsSync(legacyPkg), false);
+          check("跨 profile 卸载不误删当前 profile 目录", existsSync(join(process.env.DSH_HOME, "profiles", "desktop", "node_modules")), true);
+          check("跨 profile 卸载移除安装记录", lib.hasInstalledRecord("fake/legacy-repo"), false);
+        } finally {
+          lib.setTargetProfile("web");
+        }
+      }
+
       // detectType 判 bundle 后的独立安装路径（type=bundle 直接走 registerBundlePackage）
       const fixE = makeFixture("fake-bundle-e", "1.2.7", true);
       const logE = [];
@@ -1491,6 +1530,16 @@ function mockFetchCapture(payload, status = 200) {
   check("cve lockfile 精确版本优先", vulnDeps.find((d) => d.name === "lodash").version, "4.17.15");
   check("cve 无锁文件剥 ^ 取下界", vulnDeps.find((d) => d.name === "fsevents").version, "2.3.2");
   check("cve devDependencies 不进扫描面", vulnDeps.some((d) => d.name === "dev-only-pkg"), false);
+  // npm: 别名依赖：漏洞面在真实包上——解出真实名+版本进扫描面
+  const aliasDeps = lib.readVulnScanDeps({
+    dependencies: { "my-lodash": "npm:lodash@4.17.15", "@x/alias": "npm:@scope/pkg@2.0.0", local: "file:./p", ws: "workspace:*", lnk: "link:../q" }
+  }, new Map());
+  check("cve npm: 别名解出真实包", aliasDeps.find((d) => d.name === "lodash")?.version, "4.17.15");
+  check("cve npm: scoped 别名同款解析", aliasDeps.some((d) => d.name === "@scope/pkg" && d.version === "2.0.0"), true);
+  check("cve 本地协议（file/workspace/link）跳过", aliasDeps.every((d) => !["local", "ws", "lnk"].includes(d.name)), true);
+  // 边界：npm: 无版本段（git 分支引用形态）不误收
+  const gitAlias = lib.readVulnScanDeps({ dependencies: { g: "npm:pkg@main" } }, new Map());
+  check("cve npm: 非语义版本段按原样保留", gitAlias[0]?.version, "main");
   const cveDir = join(process.env.DSH_HOME, "cve-fixtures");
   mkdirSync(cveDir, { recursive: true });
   writeFileSync(join(cveDir, "package.json"), JSON.stringify(vulnPkg), "utf8");

--- a/scripts/tests/integration/profile.test.mjs
+++ b/scripts/tests/integration/profile.test.mjs
@@ -1,0 +1,149 @@
+// 目标 profile 配置（issue #184）行为测试：
+// - setTargetProfile 白名单校验（非法名回退 web，不抛）
+// - 路径注入拒绝：../ 等穿越段不得进入路径常量
+// - readTargetProfile：config.json 缺失/非法/目录不存在 → 回退 web
+// - profile 路由：GET 读当前值；POST 保存（非法名 400 / 不存在目录 400 / 合法 200）
+// - 写操作鉴权：POST 需 isWriteAllowed（LAN 无 token → 403）
+//
+// 独立文件的原因：profile 路径常量是模块级 let（import 时按 DSH_HOME 计算），
+// 且 setTargetProfile 会重算它们——必须独立进程隔离。
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// 必须在 import lib 之前设置临时 DSH_HOME
+process.env.DSH_HOME = mkdtempSync(join(tmpdir(), "dsh-profile-test-")).replace(/\\/g, "/");
+const home = process.env.DSH_HOME;
+const marketRoot = join(home, "marketplace");
+mkdirSync(marketRoot, { recursive: true });
+// 建 web + desktop 两个 profile（desktop 模拟 hermes 客户端场景）
+mkdirSync(join(home, "profiles", "web"), { recursive: true });
+mkdirSync(join(home, "profiles", "desktop"), { recursive: true });
+const configFile = join(marketRoot, "config.json");
+
+const lib = await import("../../../lib/index.js");
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+}
+
+// ---- setTargetProfile 白名单 ----
+check("setTargetProfile 合法名生效", lib.setTargetProfile("desktop"), "desktop");
+// 路径常量已重算（desktop）——Windows 分隔符兼容
+check("setTargetProfile 后 PROFILE_NM 指向 desktop", lib.getProfileNodeModules().includes(join("profiles", "desktop", "node_modules")), true);
+check("setTargetProfile 非法名回退 web", lib.setTargetProfile("../evil"), "web");
+check("setTargetProfile 空串回退 web", lib.setTargetProfile(""), "web");
+check("setTargetProfile 含点回退 web", lib.setTargetProfile("web.profile"), "web");
+// 恢复 web（后续测试用）
+lib.setTargetProfile("web");
+
+// ---- readTargetProfile：config.json 缺失 → web ----
+check("readTargetProfile 无配置回退 web", await lib.readTargetProfile(), "web");
+
+// ---- readTargetProfile：非法名 → web ----
+writeFileSync(configFile, JSON.stringify({ targetProfile: "../evil" }), "utf8");
+check("readTargetProfile 非法名回退 web", await lib.readTargetProfile(), "web");
+
+// ---- readTargetProfile：目录不存在 → web ----
+writeFileSync(configFile, JSON.stringify({ targetProfile: "ghost" }), "utf8");
+check("readTargetProfile 目录不存在回退 web", await lib.readTargetProfile(), "web");
+
+// ---- readTargetProfile：合法 + 目录存在 → 生效 ----
+writeFileSync(configFile, JSON.stringify({ targetProfile: "desktop" }), "utf8");
+check("readTargetProfile 合法配置生效", await lib.readTargetProfile(), "desktop");
+
+// ---- readTargetProfile：损坏 JSON → web ----
+writeFileSync(configFile, "{ broken", "utf8");
+check("readTargetProfile 损坏 JSON 回退 web", await lib.readTargetProfile(), "web");
+
+// ---- profile 路由 ----
+let registered = [];
+const fakeCtx = {
+  get: (s) => (s === "webServer" ? { register: (r) => registered.push(r) } : undefined),
+  logger: { warn: () => {}, info: () => {} },
+};
+lib.apply(fakeCtx);
+const profileHandler = registered.find((h) => h.path === "/api/marketplace/profile")?.handler;
+check("profile 路由已注册", !!profileHandler, true);
+
+// 恢复合法配置（路由测试用）
+writeFileSync(configFile, JSON.stringify({ targetProfile: "desktop" }), "utf8");
+// apply 的 readTargetProfile 是异步的——路由测试前手动应用，模拟启动完成态
+lib.setTargetProfile("desktop");
+
+const mkReq = (method, body, host = "127.0.0.1") => {
+  const bodyStr = body ? JSON.stringify(body) : "";
+  return {
+    method,
+    headers: { "x-dsh-marketplace": "1", host: "127.0.0.1:3080" },
+    socket: { remoteAddress: host },
+    url: "/api/marketplace/profile",
+    [Symbol.asyncIterator]() {
+      let sent = false;
+      return {
+        next: async () => {
+          if (!sent) { sent = true; return { value: Buffer.from(bodyStr), done: false }; }
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+};
+const mkRes = () => {
+  const out = { status: 0, body: null };
+  return {
+    writeHead: (s) => { out.status = s; },
+    end: (b) => { try { out.body = JSON.parse(b); } catch { out.body = b; } },
+    out,
+  };
+};
+
+// GET：读当前值（desktop）
+{
+  const res = mkRes();
+  await profileHandler(mkReq("GET"), res);
+  check("profile GET 返回当前值", res.out.body?.profile, "desktop");
+}
+// POST 非法名 → 400
+{
+  const res = mkRes();
+  await profileHandler(mkReq("POST", { profile: "../evil" }), res);
+  check("profile POST 非法名 400", res.out.status, 400);
+}
+// POST 不存在目录 → 400
+{
+  const res = mkRes();
+  await profileHandler(mkReq("POST", { profile: "ghost" }), res);
+  check("profile POST 不存在目录 400", res.out.status, 400);
+}
+// POST 合法 → 200 + 即时生效
+{
+  const res = mkRes();
+  await profileHandler(mkReq("POST", { profile: "desktop" }), res);
+  check("profile POST 合法 200", res.out.status, 200);
+  check("profile POST 返回新值", res.out.body?.profile, "desktop");
+  check("profile POST 后 config.json 已写", JSON.parse(readFileSync(configFile, "utf8")).targetProfile, "desktop");
+}
+// POST 空值 → 400（必须显式给合法名）
+{
+  const res = mkRes();
+  await profileHandler(mkReq("POST", { profile: "" }), res);
+  check("profile POST 空值 400", res.out.status, 400);
+}
+
+// ---- 写操作鉴权：LAN Host 无 token → 403 ----
+{
+  const res = mkRes();
+  await profileHandler(mkReq("POST", { profile: "desktop" }, "192.168.1.5"), res);
+  check("profile POST LAN 无 token 403", res.out.status, 403);
+}
+
+// ---- 清理 ----
+rmSync(home, { recursive: true, force: true });
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/tests/unit/security-guards.test.mjs
+++ b/scripts/tests/unit/security-guards.test.mjs
@@ -87,13 +87,12 @@ check("spawnSync bash 探测带 windowsHide", /spawnSync\("bash", \["--version"\
 // 卸载 bundle 主路径 pnpm remove + 降级手工清理。
 check("isBundlePackage 检测 dsh.bundle.patch 声明", /function isBundlePackage[\s\S]*?dsh\.bundle[\s\S]*?patch/.test(lib), true);
 check("registerBundlePackage 记录 dependencies + bundles 层", /registerBundlePackage[\s\S]*?manifest\.dependencies = deps;[\s\S]*?bundles\.push\(pkgName\)/.test(lib), true);
-check("registerBundlePackage 经 pnpm install 注册（cwd=profile，跳过 workspace）", /registerBundlePackage[\s\S]*?runPnpm\(\["install", "--ignore-workspace"\], \{ cwd: PROFILE_WEB_DIR/.test(lib), true);
-check("profile manifest 原子写（tmp + rename）", /const tmp = PROFILE_PKG \+ "\.tmp";[\s\S]*?rename\(tmp, PROFILE_PKG\)/.test(lib), true);
+check("registerBundlePackage 经 pnpm install 注册（cwd=profile，跳过 workspace）", /registerBundlePackage[\s\S]*?runPnpm\(\["install", "--ignore-workspace"\], \{ cwd: PROFILE_WEB_DIR/.test(lib), true);check("profile manifest 原子写（tmp + rename）", /const tmp = PROFILE_PKG \+ "\.tmp";[\s\S]*?rename\(tmp, PROFILE_PKG\)/.test(lib), true);
 check("installRepo bundle 分支在 appendPatchEntry 前 continue（不写单条 insert）", /if \(isBundlePackage\(pkg\) && repo !== SELF_UPDATE_REPO\)[\s\S]*?registerBundlePackage[\s\S]*?continue;/.test(lib), true);
 check("bundle 注册结果导向：pnpm 非零退出但包可解析 → 告警继续", /let pnpmErr = null;[\s\S]*?if \(pnpmErr\) logLine\(t\(lang, "bundlePnpmWarn"/.test(lib), true);
 check("bundle 注册验证子依赖可解析（realpath + createRequire，对齐 ESM 解析语义）", /realpath\(resolvedPkg\)[\s\S]*?createRequire\(join\(anchor, "noop\.js"\)\)[\s\S]*?bundleDepsResolveFail/.test(lib), true);
 check("bundle 依赖声明区分来源：npm 回退用版本、仓库克隆用 github: 形态", /const depSpec = typeof npmTarget === "string"[\s\S]*?\? version : `github:\$\{repo\}`/.test(lib), true);
-check("卸载 bundle 主路径 pnpm remove（跳过 workspace）", /record\.bundle === true[\s\S]*?runPnpm\(\["remove", "--ignore-workspace", pkgName\], \{ cwd: PROFILE_WEB_DIR/.test(lib), true);
+check("卸载 bundle 主路径 pnpm remove（跳过 workspace；cwd 支持跨 profile 回退）", /record\.bundle === true[\s\S]*?runPnpm\(\["remove", "--ignore-workspace", pkgName\], \{ cwd: legacyProfileDir \?\? PROFILE_WEB_DIR/.test(lib), true);
 check("卸载 bundle 降级路径手工移除 manifest 条目", /uninstallBundleDegraded[\s\S]*?delete manifest\.dependencies\[pkgName\]/.test(lib), true);
 
 // ---- 扫描边界：symlink 不跟随（扫描范围必须限于 cacheDir 内）----

--- a/scripts/tests/unit/write-access.test.mjs
+++ b/scripts/tests/unit/write-access.test.mjs
@@ -57,9 +57,9 @@ check("注入 __DSH_MP_TOKEN__ 脚本", /window\.__DSH_MP_TOKEN__="\$\{writeToke
 
 // ---- 契约 5：全部写操作端点都走 isWriteAllowed（审查 S1 鉴权统一）----
 // install / uninstall / self-update POST / feedback / feedback-token POST /
-// env-edit / backup-webdav / restore-webdav = 8 处。
+// env-edit / backup-webdav / restore-webdav / profile POST（issue #184）= 9 处。
 // 新增写端点时必须同步此处计数——漏一处即 LAN 内任意设备可无 token 写。
-check("全部写端点走 isWriteAllowed（8 处）", (lib.match(/await isWriteAllowed\(req\)\)\) return json\(res, 403/g) ?? []).length, 8);
+check("全部写端点走 isWriteAllowed（9 处）", (lib.match(/await isWriteAllowed\(req\)\)\) return json\(res, 403/g) ?? []).length, 9);
 
 // ---- 契约 6：客户端写操作带 token 头 ----
 check("client mpHeaders 存在", /function mpHeaders\(extra\) \{[\s\S]{0,200}window\.__DSH_MP_TOKEN__/.test(client), true);


### PR DESCRIPTION
## Summary

issue #184 方案 A：目标 profile 配置化——hermes desktop 等非 web profile 用户可在面板选择安装目标。

### 背景

#184 反馈：desktop profile 用户安装插件被装进 web。上游回复确认「安装管线整个绑定 web profile」，并询问用户希望「自动跟随」还是「安装时可选」。本 PR 落地**「可选」方案**（纯我方改动，不依赖上游）；「自动跟随」（宿主注入 DSH_PROFILE）留待上游协议先行。

### 实现

- **配置存储**：`config.json` 新增 `targetProfile` 键（默认 `web`），启动时读取 + 面板保存即时生效
- **路径参数化**：`PROFILE_WEB_DIR`/`PROFILE_NM`/`PATCH_FILE`/`PROFILE_PKG` 改 `let` + `setTargetProfile()` 重算——37 处引用点零改动，源码契约测试不受影响
- **安全面**：
  - profile 名白名单 `^[a-zA-Z0-9_-]+$`（防 `../` 路径穿越逃逸出 profiles/ 目录）
  - 目录存在性校验（防装进空目录）
  - POST 走 `isWriteAllowed`（回环放行 / LAN 需 lanWrite+token）
  - readTargetProfile 三重回退（非法名/目录不存在/损坏 JSON → web）
- **client**：设置区新增「目标 profile」卡片，i18n 中英

### 已知边界

CLI 指令生成（README 安装指令的 `--profile` 参数）与自更新仍按 web 写死——自动识别需宿主注入协议（见 #184 讨论），本 PR 是「可选」方案的第一步。

## Test plan

- [x] profile.test.mjs 独立进程 19 断言：白名单校验（../evil/web.profile 回退）、路径重算、readTargetProfile 四种回退、路由 GET/POST 全链路（400 非法名 / 400 不存在目录 / 200 合法 + config.json 写盘验证）、LAN 无 token 403
- [x] write-access 契约计数同步 8→9 处（新写端点必须走 isWriteAllowed 的守护测试）
- [x] 测试金字塔 35/35
- [x] 覆盖率 326/326
- [x] 突变存活 0
