### PR TITLE
test(ci): 真实 DSH 端到端 + lint 门禁兜底

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: lint-guards
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-guards-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # CI 增量密钥扫描需要基线分支的完整历史（diff base...HEAD）
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: 语法检查
+        run: node scripts/hooks/check.mjs --only=syntax
+
+      - name: 单元 + 集成测试
+        run: node scripts/hooks/check.mjs --only=tests
+
+      - name: TOC 完整性
+        run: node scripts/hooks/check.mjs --only=toc
+
+      - name: 密钥扫描（相对基线的增量，防 --no-verify 绕过本地 hook）
+        run: node scripts/hooks/check.mjs --only=secret
+        env:
+          # PR：扫相对目标分支的变更；push 到 main（多为 merge）：扫相对上一个 commit
+          CHECK_DIFF_BASE: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}

--- a/docs/GIT_HOOKS.md
+++ b/docs/GIT_HOOKS.md
@@ -121,12 +121,22 @@ bash scripts/install-hooks.sh
 - 不推荐：`git commit --no-verify`（跳过全部 hook）
 - 例外场景：紧急修复、CI 自动提交（registry.json 更新）、hook 自身迭代调试
 - 跳过时请在提交信息中注明原因（如 `ci: update registry.json (--no-verify 自动提交)`）
+- **底线在 CI**：`.github/workflows/lint.yml` 对每次 push/PR 重跑语法/单元/集成/TOC/密钥扫描——本地 `--no-verify` 绕不过 PR 门禁
+
+## 5.1 CI 增量模式（环境变量）
+
+check.mjs 支持两个环境变量（测试与 CI 用，本地无需设置）：
+
+| 变量 | 作用 |
+|---|---|
+| `CHECK_WORKTREE` | git 命令与暂存文件读取的目标工作树（默认仓库根）——hook-check.test.mjs 用临时仓库隔离 |
+| `CHECK_DIFF_BASE` | 设置后密钥扫描改用 `git diff --name-only <base>...HEAD` 扫相对基线的增量（CI checkout 无 staged 概念；lint.yml 传 PR base.sha 或 HEAD~1） |
 
 ## 6. 测试要求
 
 - 所有 hook 校验逻辑必须是**纯函数**（放 `scripts/hooks/validate.mjs` / `scripts/toc.mjs`），可被 unit 测试覆盖
 - 新增 hook 检查项必须配套断言（目标：校验逻辑 100% 覆盖）
-- Hook 编排（`check.mjs`）不直接测试，但调用链在 CI 中完整执行
+- Hook 编排（`check.mjs`）由 `scripts/tests/unit/hook-check.test.mjs` 行为测试覆盖（spawn 子进程：本地 staged 扫描 / CI 增量 / 未知 --only / --help / secretExclusions），调用链在 CI 中完整执行
 
 ## 7. 跨平台兼容约束
 

--- a/scripts/hooks/check.mjs
+++ b/scripts/hooks/check.mjs
@@ -18,6 +18,8 @@ import { fileURLToPath } from "node:url";
 import { SYNTAX_CHECK_FILES, validateSubject, extractSubject, parseHookConfig, DEFAULT_HOOK_CONFIG, detectSecret } from "./validate.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+// 检查目标工作树：本地默认仓库根；测试（hook-check.test.mjs）与 CI 场景可覆盖。
+const WORKTREE = process.env.CHECK_WORKTREE ?? ROOT;
 const USAGE = `用法:
   node scripts/hooks/check.mjs [选项]
 
@@ -135,21 +137,28 @@ function checkToc() {
   }
 }
 
-// ---- 4. 敏感密钥扫描（暂存文件）----
+// ---- 4. 敏感密钥扫描（暂存文件；CI 模式扫与基线分支的增量）----
+// 本地扫 git diff --cached（staged）；CHECK_DIFF_BASE 设置时（CI）改用
+// `git diff --name-only <base>...HEAD`——checkout 后的 CI 无 staged 概念，
+// 扫 PR 相对基线分支的实际变更（业界 gitleaks --log-opts 同语义）。
 function checkSecret() {
   if (!want("secret")) return;
-  const cfg = loadHookConfig(ROOT);
+  const cfg = loadHookConfig(WORKTREE);
   if (cfg.secretLevel === "off") return;
   try {
-    const staged = execFileSync("git", ["diff", "--cached", "--name-only"], { cwd: ROOT, encoding: "utf8" });
+    const diffBase = process.env.CHECK_DIFF_BASE;
+    const diffArgs = diffBase
+      ? ["diff", "--name-only", `${diffBase}...HEAD`]
+      : ["diff", "--cached", "--name-only"];
+    const staged = execFileSync("git", diffArgs, { cwd: WORKTREE, encoding: "utf8" });
     const files = staged.split("\n").map((s) => s.trim()).filter(Boolean);
     let found = 0;
     for (const f of files) {
       if (cfg.secretExclusions.some((ex) => f.includes(ex))) continue;
-      if (!existsSync(join(ROOT, f))) continue;
+      if (!existsSync(join(WORKTREE, f))) continue;
       let content;
       try {
-        content = readFileSync(join(ROOT, f), "utf8");
+        content = readFileSync(join(WORKTREE, f), "utf8");
       } catch {
         continue; // 二进制/编码异常跳过
       }
@@ -176,12 +185,12 @@ function checkSecret() {
 // ---- 5. 提交信息规范 ----
 function checkCommitMsg() {
   if (!want("commit-msg")) return;
-  const msgPath = process.argv.slice(2).find((a) => !a.startsWith("--")) ?? join(ROOT, ".git", "COMMIT_EDITMSG");
+  const msgPath = process.argv.slice(2).find((a) => !a.startsWith("--")) ?? join(WORKTREE, ".git", "COMMIT_EDITMSG");
   if (!existsSync(msgPath)) {
     fail("commit-msg", `未找到提交信息文件: ${msgPath}`);
   } else {
     const subject = extractSubject(readFileSync(msgPath, "utf8"));
-    const level = loadHookConfig(ROOT).emojiLevel ?? "error";
+    const level = loadHookConfig(WORKTREE).emojiLevel ?? "error";
     const r = validateSubject(subject, { emojiLevel: level });
     if (r.ok) {
       console.log(`[OK] [commit-msg] ${subject}`);

--- a/scripts/tests/e2e/real-dsh.e2e.mjs
+++ b/scripts/tests/e2e/real-dsh.e2e.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// 真实 DSH 环境端到端（#198 增补）：启动本机 dsh web，经 HTTP 验证
+// 跨 profile 状态机——profile 切换 → 列表标注/fp 随 profile 重算 → 白名单/目录校验。
+// 这是唯一覆盖「真实 DSH 宿主加载（cosmokit）→ 端口 → 鉴权 → 注入」全链路的形态。
+//
+// 前置：dsh CLI 可用（缺失或 3080 已被实例占用 → SKIP，不打扰用户运行中的实例）。
+// 运行：node scripts/tests/e2e/real-dsh.e2e.mjs
+
+import { execFileSync, spawn } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const HOST = "http://127.0.0.1:3080";
+const HEADERS = { "x-dsh-marketplace": "1" };
+
+// ---- 前置检查 ----
+let dshAvailable = true;
+try {
+  if (process.platform === "win32") {
+    execFileSync("cmd.exe", ["/c", "dsh", "--version"], { stdio: "pipe", windowsHide: true }); // .cmd 垫片 spawn EINVAL，经 cmd 包装（issue #46 同族）
+  } else {
+    execFileSync("dsh", ["--version"], { stdio: "pipe", windowsHide: true });
+  }
+} catch { dshAvailable = false; }
+if (!dshAvailable) { console.log("SKIP: dsh CLI 不可用"); process.exit(0); }
+try {
+  const probe = await fetch(`${HOST}/api/marketplace/profile`, { headers: HEADERS, signal: AbortSignal.timeout(2000) });
+  if (probe.ok) { console.log("SKIP: 3080 已有 dsh 实例在运行（请手动验证或关闭后重跑）"); process.exit(0); }
+} catch { /* 无实例：继续 */ }
+
+// ---- 启动 dsh web（Windows 经 cmd.exe /c：.cmd 垫片 spawn EINVAL，issue #46 同族）----
+let child = null;
+const cleanup = () => {
+  if (child && child.pid) {
+    try { execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], { stdio: "ignore", windowsHide: true }); } catch { try { child.kill(); } catch { /* 已退出 */ } }
+    child = null;
+  }
+};
+process.on("exit", cleanup);
+process.on("SIGINT", () => { cleanup(); process.exit(130); });
+
+const isWin = process.platform === "win32";
+child = isWin
+  ? spawn("cmd.exe", ["/c", "dsh", "web", "--no-open"], { stdio: "ignore", windowsHide: true, detached: true })
+  : spawn("dsh", ["web", "--no-open"], { stdio: "ignore", detached: true });
+
+// ---- 等待就绪（市场插件随 profile bundles 加载，profile 路由可应答即就绪；轮询 60s）----
+let ready = false;
+for (let i = 0; i < 300 && !ready; i++) {
+  await new Promise((r) => setTimeout(r, 200));
+  try {
+    const r = await fetch(`${HOST}/api/marketplace/profile`, { headers: HEADERS, signal: AbortSignal.timeout(1500) });
+    if (r.ok) ready = true;
+  } catch { /* 未就绪 */ }
+}
+if (!ready) { console.log("FAIL: dsh web 60s 内未就绪（市场插件未加载？）"); cleanup(); process.exit(1); }
+
+let pass = 0, fail = 0;
+const check = (name, actual, expected) => {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}${ok ? "" : `: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`}`);
+};
+const api = async (path, opts = {}) => {
+  const res = await fetch(HOST + path, {
+    headers: { ...HEADERS, ...(opts.json ? { "Content-Type": "application/json" } : {}) },
+    method: opts.method ?? "GET",
+    ...(opts.body ? { body: JSON.stringify(opts.body) } : {}),
+    // list 首拉需全量标注（12 worker stat 千级 repo），放大到 120s
+    signal: AbortSignal.timeout(opts.timeout ?? (path.startsWith("/api/marketplace/list") ? 120000 : 30000)),
+  });
+  let body = null;
+  try { body = await res.json(); } catch { /* 非 JSON */ }
+  return { status: res.status, body };
+};
+
+try {
+  // 1. profile GET 初始为 web
+  const p0 = await api("/api/marketplace/profile");
+  check("profile GET 初始为 web", [p0.status, p0.body?.profile], [200, "web"]);
+  // 2. 非法名（路径穿越形态）拒绝
+  const pBad = await api("/api/marketplace/profile", { method: "POST", json: true, body: { profile: "../evil" } });
+  check("profile POST 非法名 400", pBad.status, 400);
+  // 3. 不存在的 profile 拒绝（目录存在性校验）
+  const pGhost = await api("/api/marketplace/profile", { method: "POST", json: true, body: { profile: "ghost" } });
+  check("profile POST 不存在 400", pGhost.status, 400);
+  // 4. 列表初始响应：repos>0 + fp 存在
+  const l0 = await api("/api/marketplace/list?lang=zh-CN");
+  check("list 正常（repos>0 带 fp）", [l0.status, (l0.body?.repos ?? []).length > 0, typeof l0.body?.fp === "string"], [200, true, true]);
+
+  // 5-8. 切到备用 profile（除 web 外的真实目录）→ 列表 fp 必须变化（标注随 profile 重算）
+  const profilesRoot = join(homedir(), ".dsh", "profiles");
+  let altProfile = null;
+  try { altProfile = readdirSync(profilesRoot).find((d) => d !== "web" && d !== "node_modules"); } catch { /* 目录不可读 */ }
+  if (altProfile) {
+    const p1 = await api("/api/marketplace/profile", { method: "POST", json: true, body: { profile: altProfile } });
+    check(`profile POST → ${altProfile} 成功`, [p1.status, p1.body?.profile], [200, altProfile]);
+    const p2 = await api("/api/marketplace/profile");
+    check("profile GET 确认切换", p2.body?.profile, altProfile);
+    const l1 = await api("/api/marketplace/list?lang=zh-CN");
+    check("切换后列表 fp 变化（标注重算）", typeof l1.body?.fp === "string" && l1.body.fp !== l0.body?.fp, true);
+    const p3 = await api("/api/marketplace/profile", { method: "POST", json: true, body: { profile: "web" } });
+    check("切回 web", p3.body?.profile, "web");
+  } else {
+    console.log("SKIP: 无备用 profile，跳过切换断言");
+  }
+} finally {
+  cleanup();
+}
+
+console.log(`\nreal-dsh e2e: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/tests/unit/hook-check.test.mjs
+++ b/scripts/tests/unit/hook-check.test.mjs
@@ -1,0 +1,104 @@
+// Git Hook 调度器（check.mjs）行为测试：spawn 子进程验证编排逻辑。
+// 覆盖本地 staged 扫描、CI 增量扫描（CHECK_DIFF_BASE）、未知 --only、--help。
+// 与 validate.test.mjs（校验纯函数）互补——本文件测的是编排层。
+//
+// 注意：CHECK_WORKTREE 指向临时仓库，secret 扫描的 git diff 与文件读取
+// 都在临时仓库内进行，不触碰真实仓库的 index。
+
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(fileURLToPath(new URL("..", import.meta.url)), "..", "..");
+const CHECK = join(ROOT, "scripts", "hooks", "check.mjs");
+
+const run = (args, env = {}) => spawnSync("node", [CHECK, ...args], {
+  cwd: ROOT, encoding: "utf8", env: { ...process.env, ...env }, timeout: 120000, windowsHide: true,
+});
+
+let pass = 0, fail = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) pass++; else fail++;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}${ok ? "" : `: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`}`);
+}
+
+// ---- 临时 git 仓库（CHECK_WORKTREE 隔离）----
+const work = mkdtempSync(join(tmpdir(), "dsh-hook-")).replace(/\\/g, "/");
+try {
+  execFileSync("git", ["init", "-q"], { cwd: work, stdio: "pipe", windowsHide: true });
+  execFileSync("git", ["config", "user.email", "t@t"], { cwd: work, stdio: "pipe", windowsHide: true });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: work, stdio: "pipe", windowsHide: true });
+  // .hooksrc：secretLevel error（默认即 error，显式写出防默认漂移）
+  writeFileSync(join(work, ".hooksrc"), "secretLevel=error\n", "utf8");
+
+  // --help → exit 0
+  {
+    const r = run(["--help"]);
+    check("--help 退出码 0", r.status, 0);
+  }
+
+  // 未知 --only → exit 1 + 提示
+  {
+    const r = run(["--only=bogus"]);
+    check("未知 --only 退出码 1", r.status, 1);
+    check("未知 --only 输出含可用值", /syntax \| tests \| toc \| secret/.test(r.stderr), true);
+  }
+
+  // 场景 A：干净文件 staged → secret 通过
+  {
+    writeFileSync(join(work, "clean.js"), "module.exports = 1;\n", "utf8");
+    execFileSync("git", ["add", "clean.js"], { cwd: work, stdio: "pipe", windowsHide: true });
+    const r = run(["--only=secret"], { CHECK_WORKTREE: work });
+    check("干净文件 staged secret 退出码 0", r.status, 0);
+  }
+
+  // 场景 B：含密钥文件 staged → secret 拦截（error 级）
+  {
+    const sk = ["sk-", "AbCd1234EfGh5678IjKl90Mn"].join("");
+    writeFileSync(join(work, "leaky.js"), `const k = "${sk}";\n`, "utf8");
+    execFileSync("git", ["add", "leaky.js"], { cwd: work, stdio: "pipe", windowsHide: true });
+    const r = run(["--only=secret"], { CHECK_WORKTREE: work });
+    check("密钥文件 staged 退出码 1", r.status, 1);
+    check("密钥拦截输出含文件名", r.stderr.includes("leaky.js"), true);
+  }
+
+  // 场景 C：CI 增量模式（CHECK_DIFF_BASE）——扫已提交的相对基线的变更
+  {
+    // 基线：仅 clean.js 的提交
+    execFileSync("git", ["commit", "-qm", "base"], { cwd: work, stdio: "pipe", windowsHide: true });
+    // 增量提交：加密钥文件（sk- 后 ≥20 字符才命中 detectSecret 规则）
+    writeFileSync(join(work, "ci-leak.txt"), `api_key=${["sk-", "AbCd1234EfGh5678IjKl90Mn"].join("")}\n`, "utf8");
+    execFileSync("git", ["add", "ci-leak.txt"], { cwd: work, stdio: "pipe", windowsHide: true });
+    execFileSync("git", ["commit", "-qm", "add ci-leak"], { cwd: work, stdio: "pipe", windowsHide: true });
+    const r = run(["--only=secret"], { CHECK_WORKTREE: work, CHECK_DIFF_BASE: "HEAD~1" });
+    check("CI 增量模式扫到已提交密钥 退出码 1", r.status, 1);
+    check("CI 增量模式输出含增量文件名", r.stderr.includes("ci-leak.txt"), true);
+  }
+
+  // 场景 D：CI 增量模式无密钥增量 → 通过
+  {
+    writeFileSync(join(work, "ci-clean.txt"), "hello\n", "utf8");
+    execFileSync("git", ["add", "ci-clean.txt"], { cwd: work, stdio: "pipe", windowsHide: true });
+    execFileSync("git", ["commit", "-qm", "add clean"], { cwd: work, stdio: "pipe", windowsHide: true });
+    const r = run(["--only=secret"], { CHECK_WORKTREE: work, CHECK_DIFF_BASE: "HEAD~1" });
+    check("CI 增量模式干净增量 退出码 0", r.status, 0);
+  }
+
+  // 场景 E：secretExclusions 排除路径生效
+  {
+    mkdirSync(join(work, "vendor"), { recursive: true });
+    writeFileSync(join(work, "vendor", "example.txt"), `password=sk-123456\n`, "utf8");
+    execFileSync("git", ["add", "vendor/example.txt"], { cwd: work, stdio: "pipe", windowsHide: true });
+    writeFileSync(join(work, ".hooksrc"), "secretLevel=error\nsecretExclusions=vendor/\n", "utf8");
+    const r = run(["--only=secret"], { CHECK_WORKTREE: work });
+    check("secretExclusions 排除 vendor/ 退出码 0", r.status, 0);
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

#198 合并后的验证与门禁补面：真实 DSH 环境端到端 + CI lint 兜底。

### 真实 DSH 环境端到端（real-dsh.e2e.mjs）
启动本机 dsh web，经 HTTP 验证跨 profile 状态机全链路：profile 切换 → 列表标注/fp 随 profile 重算 → 白名单与目录校验 400。覆盖现有测试均无的「真实 DSH 宿主加载 → 端口 → 鉴权 → 注入」链路。dsh CLI 缺失或 3080 已有实例时自动 SKIP（不打扰运行中的实例）；Windows .cmd 垫片经 cmd.exe 包装；list 首拉标注放大到 120s；退出时 taskkill 树杀清理。

### CI lint 门禁（lint.yml）
本地 hook 可被 `--no-verify` 绕过——CI 重跑全部检查（语法/单元/集成/TOC/密钥扫描）作为真正的底线。密钥扫描用增量模式：`CHECK_DIFF_BASE` 时扫 `git diff --name-only <base>...HEAD`（PR 传 base.sha、push main 传 HEAD~1），与 gitleaks `--log-opts` 同语义；`CHECK_WORKTREE` 支持测试隔离。

### hook 编排行为测试（hook-check.test.mjs，10 断言）
spawn 子进程覆盖调度器：本地 staged 扫描（干净/含密钥/secretExclusions 排除）、CI 增量模式（已提交密钥拦截/干净增量放行）、未知 `--only` 拒绝、`--help`。

### 其他
- docs/GIT_HOOKS.md 补 CI 底线说明 + 环境变量表 + 测试要求

## Test plan

- [x] 测试金字塔 37/37；覆盖率 327/327 函数 (100%)；突变测试 24 个存活 0
- [x] real-dsh.e2e.mjs 在真实 dsh web（0.1.1-rc.2）8/8 通过；本 PR 的 lint-guards 工作流在 PR checks 中真实触发
- [x] CI 无 dsh 环境自动 SKIP（runner 上不阻塞）
