### PR TITLE
feat(security): verify-installability 加 SSRF 白名单防护

### DIFF
--- a/scripts/tests/unit/verify-probe.test.mjs
+++ b/scripts/tests/unit/verify-probe.test.mjs
@@ -2,7 +2,7 @@
 // 守护「空仓库/无分支」不误判 gone（曾有真实存在的仓库被误判删除）。
 // mock 全局 fetch（不执行 main——import 时 isMain 守卫跳过）。
 
-import { probeTree, confirmGone, verdictOf, fetchPkg } from "../../verify-installability.mjs";
+import { probeTree, confirmGone, verdictOf, fetchPkg, fetchJson } from "../../verify-installability.mjs";
 
 let pass = 0, fail = 0;
 function check(name, actual, expected) {
@@ -138,6 +138,35 @@ const TREE_OK = { tree: [{ type: "blob", path: "package.json" }, { type: "blob",
   globalThis.fetch = orig;
   check("fetchPkg 无 bundle 声明 → bundle:false", r?.bundle, false);
   check("fetchPkg 无 dsh → looksLike:false", r?.looksLike, false);
+}
+
+// ---- SSRF 防护：非白名单主机被拒绝（CWE-918）----
+// fetchJson 只允许 https://api.github.com；URL 拼自 registry.json 的 full_name
+// （外部可被 PR 篡改），恶意条目不得让探测脚本带 token 访问内网/其他主机。
+{
+  // 内网 IP（云元数据）→ 拒绝
+  let threw = false;
+  try { await fetchJson("http://169.254.169.254/latest/meta-data/"); } catch { threw = true; }
+  check("SSRF: 内网 IP 主机被拒绝", threw, true);
+}
+{
+  // 非 https 协议 → 拒绝
+  let threw = false;
+  try { await fetchJson("http://api.github.com/repos/a/b"); } catch { threw = true; }
+  check("SSRF: 非 https 协议被拒绝", threw, true);
+}
+{
+  // 非白名单 https 主机 → 拒绝
+  let threw = false;
+  try { await fetchJson("https://registry.npmjs.org/valid-package"); } catch { threw = true; }
+  check("SSRF: 非白名单 https 主机被拒绝", threw, true);
+}
+{
+  // 合法 api.github.com → 正常放行（不误伤）
+  const orig = mockFetch({ "https://api.github.com/repos/a/b": { status: 200, body: { full_name: "a/b" } } });
+  const r = await fetchJson("https://api.github.com/repos/a/b");
+  globalThis.fetch = orig;
+  check("SSRF: 合法 api.github.com 放行", r?.status, 200);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/scripts/verify-installability.mjs
+++ b/scripts/verify-installability.mjs
@@ -37,7 +37,14 @@ function tokenOf() {
 const TOKEN = tokenOf();
 const headers = { Authorization: `Bearer ${TOKEN}`, "User-Agent": "dsh-marketplace-installability-probe", "X-GitHub-Api-Version": "2022-11-28" };
 
-async function fetchJson(url, accept) {
+// SSRF 防护：URL 拼自 registry.json 的 full_name（外部可被 PR 篡改的数据），
+// 只允许 https 访问 api.github.com，禁止越权访问内网/其他主机（CWE-918）。
+const ALLOWED_HOST = "api.github.com";
+export async function fetchJson(url, accept) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" || parsed.hostname !== ALLOWED_HOST) {
+    throw new Error(`拒绝非白名单主机请求: ${parsed.hostname}`);
+  }
   const res = await fetch(url, { headers: { ...headers, ...(accept ? { Accept: accept } : {}) }, signal: AbortSignal.timeout(20000) });
   const remaining = Number(res.headers.get("x-ratelimit-remaining") ?? "0");
   const resetMs = Number(res.headers.get("x-ratelimit-reset") ?? "0") * 1000 || 0;


### PR DESCRIPTION
## Summary

`fetchJson` in `scripts/verify-installability.mjs` builds URLs from `repo.full_name` in `registry.json` (externally-controlled data a PR can tamper with). Without hostname validation, a malicious entry could make the CI probe script carry the GitHub token to internal network resources (CWE-918).

This adds a whitelist: only `https://api.github.com` is allowed; other hosts and non-https protocols are rejected.

## Origin

Adopted from external PR #213 by @anupamme (OrbisAI Security), which flagged the SSRF. We adopted the change, added the missing test, and ran the full quality gate.

## Changes

- `scripts/verify-installability.mjs`: `fetchJson` validates protocol + hostname against `api.github.com` whitelist
- `scripts/tests/unit/verify-probe.test.mjs`: +4 assertions — internal-IP host rejected, non-https rejected, non-whitelist https host rejected, valid `api.github.com` allowed

## Quality gate

unit 68/68, integration 18/18, coverage 590/590 (100%), verify-probe 18/18.